### PR TITLE
Update for release Stash@v2020.07.09-beta.0

### DIFF
--- a/data/products/stash-cli.json
+++ b/data/products/stash-cli.json
@@ -23,6 +23,10 @@
       "show": true
     },
     {
+      "version": "v0.10.0-beta.1",
+      "hostDocs": true
+    },
+    {
       "version": "v0.10.0-beta.0",
       "hostDocs": true
     },

--- a/data/products/stash-elasticsearch.json
+++ b/data/products/stash-elasticsearch.json
@@ -33,6 +33,10 @@
       "show": true
     },
     {
+      "version": "7.3.2-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "7.3.2-beta.20200708",
       "hostDocs": true
     },
@@ -40,6 +44,10 @@
       "version": "7.2.0",
       "hostDocs": true,
       "show": true
+    },
+    {
+      "version": "7.2.0-beta.20200709",
+      "hostDocs": true
     },
     {
       "version": "7.2.0-beta.20200708",
@@ -51,6 +59,10 @@
       "show": true
     },
     {
+      "version": "6.8.0-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "6.8.0-beta.20200708",
       "hostDocs": true
     },
@@ -58,6 +70,10 @@
       "version": "6.5.3",
       "hostDocs": true,
       "show": true
+    },
+    {
+      "version": "6.5.3-beta.20200709",
+      "hostDocs": true
     },
     {
       "version": "6.5.3-beta.20200708",
@@ -69,6 +85,10 @@
       "show": true
     },
     {
+      "version": "6.4.0-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "6.4.0-beta.20200708",
       "hostDocs": true
     },
@@ -76,6 +96,10 @@
       "version": "6.3.0",
       "hostDocs": true,
       "show": true
+    },
+    {
+      "version": "6.3.0-beta.20200709",
+      "hostDocs": true
     },
     {
       "version": "6.3.0-beta.20200708",
@@ -87,6 +111,10 @@
       "show": true
     },
     {
+      "version": "6.2.4-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "6.2.4-beta.20200708",
       "hostDocs": true
     },
@@ -94,6 +122,10 @@
       "version": "5.6.4",
       "hostDocs": true,
       "show": true
+    },
+    {
+      "version": "5.6.4-beta.20200709",
+      "hostDocs": true
     },
     {
       "version": "5.6.4-beta.20200708",

--- a/data/products/stash-mongodb.json
+++ b/data/products/stash-mongodb.json
@@ -33,6 +33,10 @@
       "show": true
     },
     {
+      "version": "4.2.3-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "4.2.3-beta.20200708",
       "hostDocs": true
     },
@@ -47,6 +51,10 @@
       "show": true
     },
     {
+      "version": "4.1.7-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "4.1.7-beta.20200708",
       "hostDocs": true
     },
@@ -56,7 +64,15 @@
       "show": true
     },
     {
+      "version": "4.1.4-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "4.1.4-beta.20200708",
+      "hostDocs": true
+    },
+    {
+      "version": "4.1.1-beta.20200709",
       "hostDocs": true
     },
     {
@@ -74,6 +90,10 @@
       "show": true
     },
     {
+      "version": "4.0.5-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "4.0.5-beta.20200708",
       "hostDocs": true
     },
@@ -83,7 +103,15 @@
       "show": true
     },
     {
+      "version": "4.0.3-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "4.0.3-beta.20200708",
+      "hostDocs": true
+    },
+    {
+      "version": "4.0.1-beta.20200709",
       "hostDocs": true
     },
     {
@@ -101,7 +129,15 @@
       "show": true
     },
     {
+      "version": "3.6.8-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "3.6.8-beta.20200708",
+      "hostDocs": true
+    },
+    {
+      "version": "3.6.1-beta.20200709",
       "hostDocs": true
     },
     {
@@ -119,7 +155,15 @@
       "show": true
     },
     {
+      "version": "3.4.2-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "3.4.2-beta.20200708",
+      "hostDocs": true
+    },
+    {
+      "version": "3.4.1-beta.20200709",
       "hostDocs": true
     },
     {

--- a/data/products/stash-mysql.json
+++ b/data/products/stash-mysql.json
@@ -33,6 +33,10 @@
       "show": true
     },
     {
+      "version": "8.0.14-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "8.0.14-beta.20200708",
       "hostDocs": true
     },
@@ -42,6 +46,10 @@
       "show": true
     },
     {
+      "version": "8.0.3-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "8.0.3-beta.20200708",
       "hostDocs": true
     },
@@ -49,6 +57,10 @@
       "version": "5.7.25",
       "hostDocs": true,
       "show": true
+    },
+    {
+      "version": "5.7.25-beta.20200709",
+      "hostDocs": true
     },
     {
       "version": "5.7.25-beta.20200708",

--- a/data/products/stash-percona-xtradb.json
+++ b/data/products/stash-percona-xtradb.json
@@ -33,6 +33,10 @@
       "show": true
     },
     {
+      "version": "5.7-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "5.7-beta.20200708",
       "hostDocs": true
     }

--- a/data/products/stash-postgres.json
+++ b/data/products/stash-postgres.json
@@ -33,6 +33,10 @@
       "show": true
     },
     {
+      "version": "11.2-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "11.2-beta.20200708",
       "hostDocs": true
     },
@@ -40,6 +44,10 @@
       "version": "11.1",
       "hostDocs": true,
       "show": true
+    },
+    {
+      "version": "11.1-beta.20200709",
+      "hostDocs": true
     },
     {
       "version": "11.1-beta.20200708",
@@ -51,6 +59,10 @@
       "show": true
     },
     {
+      "version": "10.6-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "10.6-beta.20200708",
       "hostDocs": true
     },
@@ -60,6 +72,10 @@
       "show": true
     },
     {
+      "version": "10.2-beta.20200709",
+      "hostDocs": true
+    },
+    {
       "version": "10.2-beta.20200708",
       "hostDocs": true
     },
@@ -67,6 +83,10 @@
       "version": "9.6",
       "hostDocs": true,
       "show": true
+    },
+    {
+      "version": "9.6-beta.20200709",
+      "hostDocs": true
     },
     {
       "version": "9.6-beta.20200708",

--- a/data/products/stash.json
+++ b/data/products/stash.json
@@ -289,6 +289,14 @@
       "show": true
     },
     {
+      "version": "v2020.07.09-beta.0",
+      "hostDocs": true,
+      "info": {
+        "catalog": "v2020.07.09-beta.0",
+        "cli": "v0.10.0-beta.1"
+      }
+    },
+    {
       "version": "v2020.07.08-beta.0",
       "hostDocs": true,
       "info": {
@@ -494,6 +502,21 @@
       "mappings": [
         {
           "versions": [
+            "v2020.07.09-beta.0"
+          ],
+          "subProjectVersions": [
+            "5.6.4-beta.20200709",
+            "6.2.4-beta.20200709",
+            "6.3.0-beta.20200709",
+            "6.4.0-beta.20200709",
+            "6.5.3-beta.20200709",
+            "6.8.0-beta.20200709",
+            "7.2.0-beta.20200709",
+            "7.3.2-beta.20200709"
+          ]
+        },
+        {
+          "versions": [
             "v2020.07.08-beta.0"
           ],
           "subProjectVersions": [
@@ -530,6 +553,24 @@
     "stash-mongodb": {
       "dir": "addons/mongodb/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2020.07.09-beta.0"
+          ],
+          "subProjectVersions": [
+            "3.4.1-beta.20200709",
+            "3.4.2-beta.20200709",
+            "3.6.1-beta.20200709",
+            "3.6.8-beta.20200709",
+            "4.0.1-beta.20200709",
+            "4.0.3-beta.20200709",
+            "4.0.5-beta.20200709",
+            "4.1.1-beta.20200709",
+            "4.1.4-beta.20200709",
+            "4.1.7-beta.20200709",
+            "4.2.3-beta.20200709"
+          ]
+        },
         {
           "versions": [
             "v2020.07.08-beta.0"
@@ -576,6 +617,16 @@
       "mappings": [
         {
           "versions": [
+            "v2020.07.09-beta.0"
+          ],
+          "subProjectVersions": [
+            "5.7.25-beta.20200709",
+            "8.0.3-beta.20200709",
+            "8.0.14-beta.20200709"
+          ]
+        },
+        {
+          "versions": [
             "v2020.07.08-beta.0"
           ],
           "subProjectVersions": [
@@ -604,6 +655,14 @@
       "mappings": [
         {
           "versions": [
+            "v2020.07.09-beta.0"
+          ],
+          "subProjectVersions": [
+            "5.7-beta.20200709"
+          ]
+        },
+        {
+          "versions": [
             "v2020.07.08-beta.0"
           ],
           "subProjectVersions": [
@@ -624,6 +683,18 @@
     "stash-postgres": {
       "dir": "addons/postgres/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2020.07.09-beta.0"
+          ],
+          "subProjectVersions": [
+            "9.6-beta.20200709",
+            "10.2-beta.20200709",
+            "10.6-beta.20200709",
+            "11.1-beta.20200709",
+            "11.2-beta.20200709"
+          ]
+        },
         {
           "versions": [
             "v2020.07.08-beta.0"


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.07.09-beta.0
Release-tracker: https://github.com/stashed/CHANGELOG/pull/2