### PR TITLE
Update for release KubeDB@v2020.07.10-beta.0

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -163,6 +163,10 @@
       "show": true
     },
     {
+      "version": "v2020.07.10-beta.0",
+      "hostDocs": true
+    },
+    {
       "version": "v0.13.0-rc.0",
       "hostDocs": true,
       "show": true


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.07.10-beta.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/3