### PR TITLE
Update for release Stash@v2020.08.26-rc.0

### DIFF
--- a/data/products/stash-cli.json
+++ b/data/products/stash-cli.json
@@ -23,6 +23,11 @@
       "show": true
     },
     {
+      "version": "v0.10.0-rc.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "v0.10.0-beta.1",
       "hostDocs": true
     },
@@ -51,5 +56,5 @@
       "show": true
     }
   ],
-  "latestVersion": "v0.3.1"
+  "latestVersion": "v0.10.0-rc.0"
 }

--- a/data/products/stash-elasticsearch.json
+++ b/data/products/stash-elasticsearch.json
@@ -33,6 +33,10 @@
       "show": true
     },
     {
+      "version": "7.3.2-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "7.3.2-beta.20200709",
       "hostDocs": true
     },
@@ -44,6 +48,10 @@
       "version": "7.2.0",
       "hostDocs": true,
       "show": true
+    },
+    {
+      "version": "7.2.0-beta.20200826",
+      "hostDocs": true
     },
     {
       "version": "7.2.0-beta.20200709",
@@ -59,6 +67,10 @@
       "show": true
     },
     {
+      "version": "6.8.0-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "6.8.0-beta.20200709",
       "hostDocs": true
     },
@@ -70,6 +82,10 @@
       "version": "6.5.3",
       "hostDocs": true,
       "show": true
+    },
+    {
+      "version": "6.5.3-beta.20200826",
+      "hostDocs": true
     },
     {
       "version": "6.5.3-beta.20200709",
@@ -85,6 +101,10 @@
       "show": true
     },
     {
+      "version": "6.4.0-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "6.4.0-beta.20200709",
       "hostDocs": true
     },
@@ -96,6 +116,10 @@
       "version": "6.3.0",
       "hostDocs": true,
       "show": true
+    },
+    {
+      "version": "6.3.0-beta.20200826",
+      "hostDocs": true
     },
     {
       "version": "6.3.0-beta.20200709",
@@ -111,6 +135,10 @@
       "show": true
     },
     {
+      "version": "6.2.4-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "6.2.4-beta.20200709",
       "hostDocs": true
     },
@@ -122,6 +150,10 @@
       "version": "5.6.4",
       "hostDocs": true,
       "show": true
+    },
+    {
+      "version": "5.6.4-beta.20200826",
+      "hostDocs": true
     },
     {
       "version": "5.6.4-beta.20200709",

--- a/data/products/stash-mongodb.json
+++ b/data/products/stash-mongodb.json
@@ -33,6 +33,10 @@
       "show": true
     },
     {
+      "version": "4.2.3-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "4.2.3-beta.20200709",
       "hostDocs": true
     },
@@ -51,6 +55,10 @@
       "show": true
     },
     {
+      "version": "4.1.7-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "4.1.7-beta.20200709",
       "hostDocs": true
     },
@@ -64,11 +72,19 @@
       "show": true
     },
     {
+      "version": "4.1.4-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "4.1.4-beta.20200709",
       "hostDocs": true
     },
     {
       "version": "4.1.4-beta.20200708",
+      "hostDocs": true
+    },
+    {
+      "version": "4.1.1-beta.20200826",
       "hostDocs": true
     },
     {
@@ -90,6 +106,10 @@
       "show": true
     },
     {
+      "version": "4.0.5-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "4.0.5-beta.20200709",
       "hostDocs": true
     },
@@ -103,11 +123,19 @@
       "show": true
     },
     {
+      "version": "4.0.3-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "4.0.3-beta.20200709",
       "hostDocs": true
     },
     {
       "version": "4.0.3-beta.20200708",
+      "hostDocs": true
+    },
+    {
+      "version": "4.0.1-beta.20200826",
       "hostDocs": true
     },
     {
@@ -129,11 +157,19 @@
       "show": true
     },
     {
+      "version": "3.6.8-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "3.6.8-beta.20200709",
       "hostDocs": true
     },
     {
       "version": "3.6.8-beta.20200708",
+      "hostDocs": true
+    },
+    {
+      "version": "3.6.1-beta.20200826",
       "hostDocs": true
     },
     {
@@ -155,11 +191,19 @@
       "show": true
     },
     {
+      "version": "3.4.2-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "3.4.2-beta.20200709",
       "hostDocs": true
     },
     {
       "version": "3.4.2-beta.20200708",
+      "hostDocs": true
+    },
+    {
+      "version": "3.4.1-beta.20200826",
       "hostDocs": true
     },
     {

--- a/data/products/stash-mysql.json
+++ b/data/products/stash-mysql.json
@@ -33,6 +33,10 @@
       "show": true
     },
     {
+      "version": "8.0.14-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "8.0.14-beta.20200709",
       "hostDocs": true
     },
@@ -46,6 +50,10 @@
       "show": true
     },
     {
+      "version": "8.0.3-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "8.0.3-beta.20200709",
       "hostDocs": true
     },
@@ -57,6 +65,10 @@
       "version": "5.7.25",
       "hostDocs": true,
       "show": true
+    },
+    {
+      "version": "5.7.25-beta.20200826",
+      "hostDocs": true
     },
     {
       "version": "5.7.25-beta.20200709",

--- a/data/products/stash-percona-xtradb.json
+++ b/data/products/stash-percona-xtradb.json
@@ -33,6 +33,10 @@
       "show": true
     },
     {
+      "version": "5.7-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "5.7-beta.20200709",
       "hostDocs": true
     },

--- a/data/products/stash-postgres.json
+++ b/data/products/stash-postgres.json
@@ -33,6 +33,10 @@
       "show": true
     },
     {
+      "version": "11.2-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "11.2-beta.20200709",
       "hostDocs": true
     },
@@ -44,6 +48,10 @@
       "version": "11.1",
       "hostDocs": true,
       "show": true
+    },
+    {
+      "version": "11.1-beta.20200826",
+      "hostDocs": true
     },
     {
       "version": "11.1-beta.20200709",
@@ -59,6 +67,10 @@
       "show": true
     },
     {
+      "version": "10.6-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "10.6-beta.20200709",
       "hostDocs": true
     },
@@ -72,6 +84,10 @@
       "show": true
     },
     {
+      "version": "10.2-beta.20200826",
+      "hostDocs": true
+    },
+    {
       "version": "10.2-beta.20200709",
       "hostDocs": true
     },
@@ -83,6 +99,10 @@
       "version": "9.6",
       "hostDocs": true,
       "show": true
+    },
+    {
+      "version": "9.6-beta.20200826",
+      "hostDocs": true
     },
     {
       "version": "9.6-beta.20200709",

--- a/data/products/stash.json
+++ b/data/products/stash.json
@@ -289,6 +289,15 @@
       "show": true
     },
     {
+      "version": "v2020.08.26-rc.0",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "catalog": "v2020.08.26-rc.0",
+        "cli": "v0.10.0-rc.0"
+      }
+    },
+    {
       "version": "v2020.07.09-beta.0",
       "hostDocs": true,
       "info": {
@@ -425,7 +434,7 @@
       "show": true
     }
   ],
-  "latestVersion": "v0.9.0-rc.6",
+  "latestVersion": "v2020.08.26-rc.0",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/stashed/stash",
@@ -502,6 +511,21 @@
       "mappings": [
         {
           "versions": [
+            "v2020.08.26-rc.0"
+          ],
+          "subProjectVersions": [
+            "5.6.4-beta.20200826",
+            "6.2.4-beta.20200826",
+            "6.3.0-beta.20200826",
+            "6.4.0-beta.20200826",
+            "6.5.3-beta.20200826",
+            "6.8.0-beta.20200826",
+            "7.2.0-beta.20200826",
+            "7.3.2-beta.20200826"
+          ]
+        },
+        {
+          "versions": [
             "v2020.07.09-beta.0"
           ],
           "subProjectVersions": [
@@ -553,6 +577,24 @@
     "stash-mongodb": {
       "dir": "addons/mongodb/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2020.08.26-rc.0"
+          ],
+          "subProjectVersions": [
+            "3.4.1-beta.20200826",
+            "3.4.2-beta.20200826",
+            "3.6.1-beta.20200826",
+            "3.6.8-beta.20200826",
+            "4.0.1-beta.20200826",
+            "4.0.3-beta.20200826",
+            "4.0.5-beta.20200826",
+            "4.1.1-beta.20200826",
+            "4.1.4-beta.20200826",
+            "4.1.7-beta.20200826",
+            "4.2.3-beta.20200826"
+          ]
+        },
         {
           "versions": [
             "v2020.07.09-beta.0"
@@ -617,6 +659,16 @@
       "mappings": [
         {
           "versions": [
+            "v2020.08.26-rc.0"
+          ],
+          "subProjectVersions": [
+            "5.7.25-beta.20200826",
+            "8.0.3-beta.20200826",
+            "8.0.14-beta.20200826"
+          ]
+        },
+        {
+          "versions": [
             "v2020.07.09-beta.0"
           ],
           "subProjectVersions": [
@@ -655,6 +707,14 @@
       "mappings": [
         {
           "versions": [
+            "v2020.08.26-rc.0"
+          ],
+          "subProjectVersions": [
+            "5.7-beta.20200826"
+          ]
+        },
+        {
+          "versions": [
             "v2020.07.09-beta.0"
           ],
           "subProjectVersions": [
@@ -683,6 +743,18 @@
     "stash-postgres": {
       "dir": "addons/postgres/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2020.08.26-rc.0"
+          ],
+          "subProjectVersions": [
+            "9.6-beta.20200826",
+            "10.2-beta.20200826",
+            "10.6-beta.20200826",
+            "11.1-beta.20200826",
+            "11.2-beta.20200826"
+          ]
+        },
         {
           "versions": [
             "v2020.07.09-beta.0"


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.08.26-rc.0
Release-tracker: https://github.com/stashed/CHANGELOG/pull/4