### PR TITLE
Update for release Stash@v2020.08.26-rc.1

### DIFF
--- a/data/products/stash-cli.json
+++ b/data/products/stash-cli.json
@@ -23,6 +23,11 @@
       "show": true
     },
     {
+      "version": "v0.10.0-rc.1",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "v0.10.0-rc.0",
       "hostDocs": true,
       "show": true
@@ -56,5 +61,5 @@
       "show": true
     }
   ],
-  "latestVersion": "v0.10.0-rc.0"
+  "latestVersion": "v0.10.0-rc.1"
 }

--- a/data/products/stash-elasticsearch.json
+++ b/data/products/stash-elasticsearch.json
@@ -33,6 +33,11 @@
       "show": true
     },
     {
+      "version": "7.3.2-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "7.3.2-beta.20200826",
       "hostDocs": true
     },
@@ -46,6 +51,11 @@
     },
     {
       "version": "7.2.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "7.2.0-rc.20200826",
       "hostDocs": true,
       "show": true
     },
@@ -67,6 +77,11 @@
       "show": true
     },
     {
+      "version": "6.8.0-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.8.0-beta.20200826",
       "hostDocs": true
     },
@@ -80,6 +95,11 @@
     },
     {
       "version": "6.5.3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "6.5.3-rc.20200826",
       "hostDocs": true,
       "show": true
     },
@@ -101,6 +121,11 @@
       "show": true
     },
     {
+      "version": "6.4.0-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.4.0-beta.20200826",
       "hostDocs": true
     },
@@ -114,6 +139,11 @@
     },
     {
       "version": "6.3.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "6.3.0-rc.20200826",
       "hostDocs": true,
       "show": true
     },
@@ -135,6 +165,11 @@
       "show": true
     },
     {
+      "version": "6.2.4-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.2.4-beta.20200826",
       "hostDocs": true
     },
@@ -148,6 +183,11 @@
     },
     {
       "version": "5.6.4",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "5.6.4-rc.20200826",
       "hostDocs": true,
       "show": true
     },

--- a/data/products/stash-mongodb.json
+++ b/data/products/stash-mongodb.json
@@ -33,6 +33,11 @@
       "show": true
     },
     {
+      "version": "4.2.3-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.2.3-beta.20200826",
       "hostDocs": true
     },
@@ -55,6 +60,11 @@
       "show": true
     },
     {
+      "version": "4.1.7-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.1.7-beta.20200826",
       "hostDocs": true
     },
@@ -72,6 +82,11 @@
       "show": true
     },
     {
+      "version": "4.1.4-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.1.4-beta.20200826",
       "hostDocs": true
     },
@@ -82,6 +97,11 @@
     {
       "version": "4.1.4-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "4.1.1-rc.20200826",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "4.1.1-beta.20200826",
@@ -101,7 +121,17 @@
       "show": true
     },
     {
+      "version": "4.0.11-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.0.5",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.0.5-rc.20200826",
       "hostDocs": true,
       "show": true
     },
@@ -119,6 +149,11 @@
     },
     {
       "version": "4.0.3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.0.3-rc.20200826",
       "hostDocs": true,
       "show": true
     },
@@ -157,6 +192,11 @@
       "show": true
     },
     {
+      "version": "3.6.8-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.6.8-beta.20200826",
       "hostDocs": true
     },
@@ -167,6 +207,11 @@
     {
       "version": "3.6.8-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "3.6.1-rc.20200826",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "3.6.1-beta.20200826",
@@ -191,6 +236,11 @@
       "show": true
     },
     {
+      "version": "3.4.2-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.4.2-beta.20200826",
       "hostDocs": true
     },
@@ -201,6 +251,11 @@
     {
       "version": "3.4.2-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "3.4.1-rc.20200826",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "3.4.1-beta.20200826",

--- a/data/products/stash-mysql.json
+++ b/data/products/stash-mysql.json
@@ -33,6 +33,11 @@
       "show": true
     },
     {
+      "version": "8.0.14-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "8.0.14-beta.20200826",
       "hostDocs": true
     },
@@ -50,6 +55,11 @@
       "show": true
     },
     {
+      "version": "8.0.3-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "8.0.3-beta.20200826",
       "hostDocs": true
     },
@@ -63,6 +73,11 @@
     },
     {
       "version": "5.7.25",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "5.7.25-rc.20200826",
       "hostDocs": true,
       "show": true
     },

--- a/data/products/stash-percona-xtradb.json
+++ b/data/products/stash-percona-xtradb.json
@@ -33,6 +33,11 @@
       "show": true
     },
     {
+      "version": "5.7-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "5.7-beta.20200826",
       "hostDocs": true
     },

--- a/data/products/stash-postgres.json
+++ b/data/products/stash-postgres.json
@@ -33,6 +33,11 @@
       "show": true
     },
     {
+      "version": "11.2-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "11.2-beta.20200826",
       "hostDocs": true
     },
@@ -46,6 +51,11 @@
     },
     {
       "version": "11.1",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "11.1-rc.20200826",
       "hostDocs": true,
       "show": true
     },
@@ -67,6 +77,11 @@
       "show": true
     },
     {
+      "version": "10.6-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "10.6-beta.20200826",
       "hostDocs": true
     },
@@ -84,6 +99,11 @@
       "show": true
     },
     {
+      "version": "10.2-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "10.2-beta.20200826",
       "hostDocs": true
     },
@@ -97,6 +117,11 @@
     },
     {
       "version": "9.6",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "9.6-rc.20200826",
       "hostDocs": true,
       "show": true
     },

--- a/data/products/stash.json
+++ b/data/products/stash.json
@@ -289,6 +289,15 @@
       "show": true
     },
     {
+      "version": "v2020.08.26-rc.1",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "catalog": "v2020.08.26-rc.1",
+        "cli": "v0.10.0-rc.1"
+      }
+    },
+    {
       "version": "v2020.08.26-rc.0",
       "hostDocs": true,
       "show": true,
@@ -434,7 +443,7 @@
       "show": true
     }
   ],
-  "latestVersion": "v2020.08.26-rc.0",
+  "latestVersion": "v2020.08.26-rc.1",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/stashed/stash",
@@ -511,6 +520,21 @@
       "mappings": [
         {
           "versions": [
+            "v2020.08.26-rc.1"
+          ],
+          "subProjectVersions": [
+            "5.6.4-rc.20200826",
+            "6.2.4-rc.20200826",
+            "6.3.0-rc.20200826",
+            "6.4.0-rc.20200826",
+            "6.5.3-rc.20200826",
+            "6.8.0-rc.20200826",
+            "7.2.0-rc.20200826",
+            "7.3.2-rc.20200826"
+          ]
+        },
+        {
+          "versions": [
             "v2020.08.26-rc.0"
           ],
           "subProjectVersions": [
@@ -577,6 +601,24 @@
     "stash-mongodb": {
       "dir": "addons/mongodb/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2020.08.26-rc.1"
+          ],
+          "subProjectVersions": [
+            "3.4.1-rc.20200826",
+            "3.4.2-rc.20200826",
+            "3.6.1-rc.20200826",
+            "3.6.8-rc.20200826",
+            "4.0.3-rc.20200826",
+            "4.0.5-rc.20200826",
+            "4.0.11-rc.20200826",
+            "4.1.1-rc.20200826",
+            "4.1.4-rc.20200826",
+            "4.1.7-rc.20200826",
+            "4.2.3-rc.20200826"
+          ]
+        },
         {
           "versions": [
             "v2020.08.26-rc.0"
@@ -659,6 +701,16 @@
       "mappings": [
         {
           "versions": [
+            "v2020.08.26-rc.1"
+          ],
+          "subProjectVersions": [
+            "5.7.25-rc.20200826",
+            "8.0.3-rc.20200826",
+            "8.0.14-rc.20200826"
+          ]
+        },
+        {
+          "versions": [
             "v2020.08.26-rc.0"
           ],
           "subProjectVersions": [
@@ -707,6 +759,14 @@
       "mappings": [
         {
           "versions": [
+            "v2020.08.26-rc.1"
+          ],
+          "subProjectVersions": [
+            "5.7-rc.20200826"
+          ]
+        },
+        {
+          "versions": [
             "v2020.08.26-rc.0"
           ],
           "subProjectVersions": [
@@ -743,6 +803,18 @@
     "stash-postgres": {
       "dir": "addons/postgres/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2020.08.26-rc.1"
+          ],
+          "subProjectVersions": [
+            "9.6-rc.20200826",
+            "10.2-rc.20200826",
+            "10.6-rc.20200826",
+            "11.1-rc.20200826",
+            "11.2-rc.20200826"
+          ]
+        },
         {
           "versions": [
             "v2020.08.26-rc.0"


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.08.26-rc.1
Release-tracker: https://github.com/stashed/CHANGELOG/pull/5