### PR TITLE
Update for release Stash@v2020.08.27-rc.0

### DIFF
--- a/data/products/stash-cli.json
+++ b/data/products/stash-cli.json
@@ -23,6 +23,11 @@
       "show": true
     },
     {
+      "version": "v0.10.0-rc.2",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "v0.10.0-rc.1",
       "hostDocs": true,
       "show": true
@@ -61,5 +66,5 @@
       "show": true
     }
   ],
-  "latestVersion": "v0.10.0-rc.1"
+  "latestVersion": "v0.10.0-rc.2"
 }

--- a/data/products/stash-elasticsearch.json
+++ b/data/products/stash-elasticsearch.json
@@ -33,6 +33,11 @@
       "show": true
     },
     {
+      "version": "7.3.2-rc.20200827",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "7.3.2-rc.20200826",
       "hostDocs": true,
       "show": true
@@ -51,6 +56,11 @@
     },
     {
       "version": "7.2.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "7.2.0-rc.20200827",
       "hostDocs": true,
       "show": true
     },
@@ -77,6 +87,11 @@
       "show": true
     },
     {
+      "version": "6.8.0-rc.20200827",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.8.0-rc.20200826",
       "hostDocs": true,
       "show": true
@@ -95,6 +110,11 @@
     },
     {
       "version": "6.5.3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "6.5.3-rc.20200827",
       "hostDocs": true,
       "show": true
     },
@@ -121,6 +141,11 @@
       "show": true
     },
     {
+      "version": "6.4.0-rc.20200827",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.4.0-rc.20200826",
       "hostDocs": true,
       "show": true
@@ -139,6 +164,11 @@
     },
     {
       "version": "6.3.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "6.3.0-rc.20200827",
       "hostDocs": true,
       "show": true
     },
@@ -165,6 +195,11 @@
       "show": true
     },
     {
+      "version": "6.2.4-rc.20200827",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.2.4-rc.20200826",
       "hostDocs": true,
       "show": true
@@ -183,6 +218,11 @@
     },
     {
       "version": "5.6.4",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "5.6.4-rc.20200827",
       "hostDocs": true,
       "show": true
     },

--- a/data/products/stash-mongodb.json
+++ b/data/products/stash-mongodb.json
@@ -33,6 +33,11 @@
       "show": true
     },
     {
+      "version": "4.2.3-rc.20200827",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.2.3-rc.20200826",
       "hostDocs": true,
       "show": true
@@ -60,6 +65,11 @@
       "show": true
     },
     {
+      "version": "4.1.7-rc.20200827",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.1.7-rc.20200826",
       "hostDocs": true,
       "show": true
@@ -82,6 +92,11 @@
       "show": true
     },
     {
+      "version": "4.1.4-rc.20200827",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.1.4-rc.20200826",
       "hostDocs": true,
       "show": true
@@ -97,6 +112,11 @@
     {
       "version": "4.1.4-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "4.1.1-rc.20200827",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "4.1.1-rc.20200826",
@@ -121,12 +141,22 @@
       "show": true
     },
     {
+      "version": "4.0.11-rc.20200827",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.0.11-rc.20200826",
       "hostDocs": true,
       "show": true
     },
     {
       "version": "4.0.5",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.0.5-rc.20200827",
       "hostDocs": true,
       "show": true
     },
@@ -149,6 +179,11 @@
     },
     {
       "version": "4.0.3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.0.3-rc.20200827",
       "hostDocs": true,
       "show": true
     },
@@ -192,6 +227,11 @@
       "show": true
     },
     {
+      "version": "3.6.8-rc.20200827",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.6.8-rc.20200826",
       "hostDocs": true,
       "show": true
@@ -207,6 +247,11 @@
     {
       "version": "3.6.8-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "3.6.1-rc.20200827",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "3.6.1-rc.20200826",
@@ -236,6 +281,11 @@
       "show": true
     },
     {
+      "version": "3.4.2-rc.20200827",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.4.2-rc.20200826",
       "hostDocs": true,
       "show": true
@@ -251,6 +301,11 @@
     {
       "version": "3.4.2-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "3.4.1-rc.20200827",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "3.4.1-rc.20200826",

--- a/data/products/stash-mysql.json
+++ b/data/products/stash-mysql.json
@@ -33,6 +33,11 @@
       "show": true
     },
     {
+      "version": "8.0.14-rc.20200827",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "8.0.14-rc.20200826",
       "hostDocs": true,
       "show": true
@@ -55,6 +60,11 @@
       "show": true
     },
     {
+      "version": "8.0.3-rc.20200827",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "8.0.3-rc.20200826",
       "hostDocs": true,
       "show": true
@@ -73,6 +83,11 @@
     },
     {
       "version": "5.7.25",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "5.7.25-rc.20200827",
       "hostDocs": true,
       "show": true
     },

--- a/data/products/stash-percona-xtradb.json
+++ b/data/products/stash-percona-xtradb.json
@@ -33,6 +33,11 @@
       "show": true
     },
     {
+      "version": "5.7-rc.20200827",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "5.7-rc.20200826",
       "hostDocs": true,
       "show": true

--- a/data/products/stash-postgres.json
+++ b/data/products/stash-postgres.json
@@ -33,6 +33,11 @@
       "show": true
     },
     {
+      "version": "11.2-rc.20200827",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "11.2-rc.20200826",
       "hostDocs": true,
       "show": true
@@ -51,6 +56,11 @@
     },
     {
       "version": "11.1",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "11.1-rc.20200827",
       "hostDocs": true,
       "show": true
     },
@@ -77,6 +87,11 @@
       "show": true
     },
     {
+      "version": "10.6-rc.20200827",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "10.6-rc.20200826",
       "hostDocs": true,
       "show": true
@@ -99,6 +114,11 @@
       "show": true
     },
     {
+      "version": "10.2-rc.20200827",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "10.2-rc.20200826",
       "hostDocs": true,
       "show": true
@@ -117,6 +137,11 @@
     },
     {
       "version": "9.6",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "9.6-rc.20200827",
       "hostDocs": true,
       "show": true
     },

--- a/data/products/stash.json
+++ b/data/products/stash.json
@@ -289,6 +289,17 @@
       "show": true
     },
     {
+      "version": "v2020.08.27-rc.0",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "catalog": "v2020.08.27-rc.0",
+        "cli": "v0.10.0-rc.2",
+        "community": "v0.10.0-rc.2",
+        "enterprise": "v0.10.0-rc.2"
+      }
+    },
+    {
       "version": "v2020.08.26-rc.1",
       "hostDocs": true,
       "show": true,
@@ -443,7 +454,7 @@
       "show": true
     }
   ],
-  "latestVersion": "v2020.08.26-rc.1",
+  "latestVersion": "v2020.08.27-rc.0",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/stashed/stash",
@@ -518,6 +529,21 @@
     "stash-elasticsearch": {
       "dir": "addons/elasticsearch/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2020.08.27-rc.0"
+          ],
+          "subProjectVersions": [
+            "5.6.4-rc.20200827",
+            "6.2.4-rc.20200827",
+            "6.3.0-rc.20200827",
+            "6.4.0-rc.20200827",
+            "6.5.3-rc.20200827",
+            "6.8.0-rc.20200827",
+            "7.2.0-rc.20200827",
+            "7.3.2-rc.20200827"
+          ]
+        },
         {
           "versions": [
             "v2020.08.26-rc.1"
@@ -601,6 +627,24 @@
     "stash-mongodb": {
       "dir": "addons/mongodb/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2020.08.27-rc.0"
+          ],
+          "subProjectVersions": [
+            "3.4.1-rc.20200827",
+            "3.4.2-rc.20200827",
+            "3.6.1-rc.20200827",
+            "3.6.8-rc.20200827",
+            "4.0.3-rc.20200827",
+            "4.0.5-rc.20200827",
+            "4.0.11-rc.20200827",
+            "4.1.1-rc.20200827",
+            "4.1.4-rc.20200827",
+            "4.1.7-rc.20200827",
+            "4.2.3-rc.20200827"
+          ]
+        },
         {
           "versions": [
             "v2020.08.26-rc.1"
@@ -701,6 +745,16 @@
       "mappings": [
         {
           "versions": [
+            "v2020.08.27-rc.0"
+          ],
+          "subProjectVersions": [
+            "5.7.25-rc.20200827",
+            "8.0.3-rc.20200827",
+            "8.0.14-rc.20200827"
+          ]
+        },
+        {
+          "versions": [
             "v2020.08.26-rc.1"
           ],
           "subProjectVersions": [
@@ -759,6 +813,14 @@
       "mappings": [
         {
           "versions": [
+            "v2020.08.27-rc.0"
+          ],
+          "subProjectVersions": [
+            "5.7-rc.20200827"
+          ]
+        },
+        {
+          "versions": [
             "v2020.08.26-rc.1"
           ],
           "subProjectVersions": [
@@ -803,6 +865,18 @@
     "stash-postgres": {
       "dir": "addons/postgres/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2020.08.27-rc.0"
+          ],
+          "subProjectVersions": [
+            "9.6-rc.20200827",
+            "10.2-rc.20200827",
+            "10.6-rc.20200827",
+            "11.1-rc.20200827",
+            "11.2-rc.20200827"
+          ]
+        },
         {
           "versions": [
             "v2020.08.26-rc.1"


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.08.27-rc.0
Release-tracker: https://github.com/stashed/CHANGELOG/pull/6