### PR TITLE
Update for release Stash@v2020.10.21

### DIFF
--- a/data/products/stash-cli.json
+++ b/data/products/stash-cli.json
@@ -23,6 +23,55 @@
       "show": true
     },
     {
+      "version": "v0.11.3",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "stash": "v2020.10.21",
+        "stash-catalog": "v2020.10.21",
+        "stash-community": "v0.11.3",
+        "stash-elasticsearch": [
+          "5.6.4-v3",
+          "6.2.4-v3",
+          "6.3.0-v3",
+          "6.4.0-v3",
+          "6.5.3-v3",
+          "6.8.0-v3",
+          "7.2.0-v3",
+          "7.3.2-v3"
+        ],
+        "stash-enterprise": "v0.11.3",
+        "stash-installer": "v0.11.3",
+        "stash-mongodb": [
+          "3.4.17-v3",
+          "3.4.22-v3",
+          "3.6.13-v3",
+          "3.6.8-v3",
+          "4.0.11-v3",
+          "4.0.3-v3",
+          "4.0.5-v3",
+          "4.1.13-v3",
+          "4.1.4-v3",
+          "4.1.7-v3",
+          "4.2.3-v3"
+        ],
+        "stash-mysql": [
+          "5.7.25-v3",
+          "8.0.14-v3",
+          "8.0.3-v3"
+        ],
+        "stash-percona-xtradb": [
+          "5.7-v3"
+        ],
+        "stash-postgres": [
+          "10.14.0-v1",
+          "11.9.0-v1",
+          "12.4.0-v1",
+          "9.6.19-v1"
+        ]
+      }
+    },
+    {
       "version": "v0.11.2",
       "hostDocs": true,
       "show": true
@@ -81,5 +130,5 @@
       "show": true
     }
   ],
-  "latestVersion": "v0.11.2"
+  "latestVersion": "v0.11.3"
 }

--- a/data/products/stash-elasticsearch.json
+++ b/data/products/stash-elasticsearch.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "7.3.2-v3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "7.3.2-v2",
       "hostDocs": true,
       "show": true
@@ -63,6 +68,11 @@
     {
       "version": "7.3.2-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "7.2.0-v3",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "7.2.0-v2",
@@ -102,6 +112,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.8.0-v3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.8.0-v2",
       "hostDocs": true,
       "show": true
@@ -137,6 +152,11 @@
     {
       "version": "6.8.0-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "6.5.3-v3",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "6.5.3-v2",
@@ -176,6 +196,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.4.0-v3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.4.0-v2",
       "hostDocs": true,
       "show": true
@@ -211,6 +236,11 @@
     {
       "version": "6.4.0-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "6.3.0-v3",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "6.3.0-v2",
@@ -250,6 +280,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.2.4-v3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.2.4-v2",
       "hostDocs": true,
       "show": true
@@ -285,6 +320,11 @@
     {
       "version": "6.2.4-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "5.6.4-v3",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "5.6.4-v2",
@@ -324,5 +364,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "7.3.2-v2"
+  "latestVersion": "7.3.2-v3"
 }

--- a/data/products/stash-mongodb.json
+++ b/data/products/stash-mongodb.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "4.2.3-v3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.2.3-v2",
       "hostDocs": true,
       "show": true
@@ -65,6 +70,11 @@
       "hostDocs": true
     },
     {
+      "version": "4.1.13-v3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.1.13-v2",
       "hostDocs": true,
       "show": true
@@ -76,6 +86,11 @@
     },
     {
       "version": "4.1.13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.1.7-v3",
       "hostDocs": true,
       "show": true
     },
@@ -115,6 +130,11 @@
     {
       "version": "4.1.7-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "4.1.4-v3",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "4.1.4-v2",
@@ -176,6 +196,11 @@
       "hostDocs": true
     },
     {
+      "version": "4.0.11-v3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.0.11-v2",
       "hostDocs": true,
       "show": true
@@ -197,6 +222,11 @@
     },
     {
       "version": "4.0.11-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.0.5-v3",
       "hostDocs": true,
       "show": true
     },
@@ -236,6 +266,11 @@
     {
       "version": "4.0.5-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "4.0.3-v3",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "4.0.3-v2",
@@ -287,6 +322,11 @@
       "hostDocs": true
     },
     {
+      "version": "3.6.13-v3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.6.13-v2",
       "hostDocs": true,
       "show": true
@@ -298,6 +338,11 @@
     },
     {
       "version": "3.6.13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "3.6.8-v3",
       "hostDocs": true,
       "show": true
     },
@@ -361,6 +406,11 @@
       "hostDocs": true
     },
     {
+      "version": "3.4.22-v3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.4.22-v2",
       "hostDocs": true,
       "show": true
@@ -372,6 +422,11 @@
     },
     {
       "version": "3.4.22",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "3.4.17-v3",
       "hostDocs": true,
       "show": true
     },
@@ -435,5 +490,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "4.2.3-v2"
+  "latestVersion": "4.2.3-v3"
 }

--- a/data/products/stash-mysql.json
+++ b/data/products/stash-mysql.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "8.0.14-v3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "8.0.14-v2",
       "hostDocs": true,
       "show": true
@@ -63,6 +68,11 @@
     {
       "version": "8.0.14-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "8.0.3-v3",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "8.0.3-v2",
@@ -102,6 +112,11 @@
       "hostDocs": true
     },
     {
+      "version": "5.7.25-v3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "5.7.25-v2",
       "hostDocs": true,
       "show": true
@@ -139,5 +154,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "8.0.14-v2"
+  "latestVersion": "8.0.14-v3"
 }

--- a/data/products/stash-percona-xtradb.json
+++ b/data/products/stash-percona-xtradb.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "5.7-v3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "5.7-v2",
       "hostDocs": true,
       "show": true
@@ -65,5 +70,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "5.7-v2"
+  "latestVersion": "5.7-v3"
 }

--- a/data/products/stash-postgres.json
+++ b/data/products/stash-postgres.json
@@ -28,7 +28,17 @@
       "show": true
     },
     {
+      "version": "12.4.0-v1",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "12.4.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "11.9.0-v1",
       "hostDocs": true,
       "show": true
     },
@@ -102,6 +112,11 @@
       "hostDocs": true
     },
     {
+      "version": "10.14.0-v1",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "10.14.0",
       "hostDocs": true,
       "show": true
@@ -171,6 +186,11 @@
       "hostDocs": true
     },
     {
+      "version": "9.6.19-v1",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "9.6.19",
       "hostDocs": true,
       "show": true
@@ -208,5 +228,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "12.4.0"
+  "latestVersion": "12.4.0-v1"
 }

--- a/data/products/stash.json
+++ b/data/products/stash.json
@@ -299,6 +299,55 @@
       "show": true
     },
     {
+      "version": "v2020.10.21",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "catalog": "v2020.10.21",
+        "cli": "v0.11.3",
+        "community": "v0.11.3",
+        "elasticsearch": [
+          "5.6.4-v3",
+          "6.2.4-v3",
+          "6.3.0-v3",
+          "6.4.0-v3",
+          "6.5.3-v3",
+          "6.8.0-v3",
+          "7.2.0-v3",
+          "7.3.2-v3"
+        ],
+        "enterprise": "v0.11.3",
+        "installer": "v0.11.3",
+        "mongodb": [
+          "3.4.17-v3",
+          "3.4.22-v3",
+          "3.6.13-v3",
+          "3.6.8-v3",
+          "4.0.11-v3",
+          "4.0.3-v3",
+          "4.0.5-v3",
+          "4.1.13-v3",
+          "4.1.4-v3",
+          "4.1.7-v3",
+          "4.2.3-v3"
+        ],
+        "mysql": [
+          "5.7.25-v3",
+          "8.0.14-v3",
+          "8.0.3-v3"
+        ],
+        "percona-xtradb": [
+          "5.7-v3"
+        ],
+        "postgres": [
+          "10.14.0-v1",
+          "11.9.0-v1",
+          "12.4.0-v1",
+          "9.6.19-v1"
+        ]
+      }
+    },
+    {
       "version": "v2020.09.29",
       "hostDocs": true,
       "show": true,
@@ -557,7 +606,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2020.09.29",
+  "latestVersion": "v2020.10.21",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/stashed/stash",
@@ -632,6 +681,21 @@
     "stash-elasticsearch": {
       "dir": "addons/elasticsearch/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2020.10.21"
+          ],
+          "subProjectVersions": [
+            "5.6.4-v3",
+            "6.2.4-v3",
+            "6.3.0-v3",
+            "6.4.0-v3",
+            "6.5.3-v3",
+            "6.8.0-v3",
+            "7.2.0-v3",
+            "7.3.2-v3"
+          ]
+        },
         {
           "versions": [
             "v2020.09.16",
@@ -761,6 +825,24 @@
     "stash-mongodb": {
       "dir": "addons/mongodb/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2020.10.21"
+          ],
+          "subProjectVersions": [
+            "3.4.17-v3",
+            "3.4.22-v3",
+            "3.6.8-v3",
+            "3.6.13-v3",
+            "4.0.3-v3",
+            "4.0.5-v3",
+            "4.0.11-v3",
+            "4.1.4-v3",
+            "4.1.7-v3",
+            "4.1.13-v3",
+            "4.2.3-v3"
+          ]
+        },
         {
           "versions": [
             "v2020.09.16",
@@ -916,6 +998,16 @@
       "mappings": [
         {
           "versions": [
+            "v2020.10.21"
+          ],
+          "subProjectVersions": [
+            "5.7.25-v3",
+            "8.0.3-v3",
+            "8.0.14-v3"
+          ]
+        },
+        {
+          "versions": [
             "v2020.09.16",
             "v2020.09.29"
           ],
@@ -1005,6 +1097,14 @@
       "mappings": [
         {
           "versions": [
+            "v2020.10.21"
+          ],
+          "subProjectVersions": [
+            "5.7-v3"
+          ]
+        },
+        {
+          "versions": [
             "v2020.09.16",
             "v2020.09.29"
           ],
@@ -1074,6 +1174,17 @@
     "stash-postgres": {
       "dir": "addons/postgres/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2020.10.21"
+          ],
+          "subProjectVersions": [
+            "9.6.19-v1",
+            "10.14.0-v1",
+            "11.9.0-v1",
+            "12.4.0-v1"
+          ]
+        },
         {
           "versions": [
             "v2020.09.16",


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.10.21
Release-tracker: https://github.com/stashed/CHANGELOG/pull/16