### PR TITLE
Update for release KubeDB@v2020.10.26-beta.0

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -163,6 +163,16 @@
       "show": true
     },
     {
+      "version": "v2020.10.26-beta.0",
+      "hostDocs": true,
+      "info": {
+        "cli": "v0.14.0-beta.5",
+        "community": "v0.14.0-beta.5",
+        "enterprise": "v0.1.0-beta.5",
+        "installer": "v0.14.0-beta.5"
+      }
+    },
+    {
       "version": "v2020.10.24-beta.0",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.10.26-beta.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/16