### PR TITLE
Update for release KubeDB@v2020.10.27-rc.0

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -163,6 +163,17 @@
       "show": true
     },
     {
+      "version": "v2020.10.27-rc.0",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.14.0-beta.6",
+        "community": "v0.14.0-beta.6",
+        "enterprise": "v0.1.0-beta.6",
+        "installer": "v0.14.0-beta.6"
+      }
+    },
+    {
       "version": "v2020.10.26-beta.0",
       "hostDocs": true,
       "info": {
@@ -254,7 +265,7 @@
       "show": true
     }
   ],
-  "latestVersion": "v0.13.0-rc.0",
+  "latestVersion": "v2020.10.27-rc.0",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubedb/cli",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.10.27-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/17