### PR TITLE
Update for release KubeDB@v2020.10.27-rc.1

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -163,6 +163,17 @@
       "show": true
     },
     {
+      "version": "v2020.10.27-rc.1",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.14.0-rc.1",
+        "community": "v0.14.0-rc.1",
+        "enterprise": "v0.1.0-rc.1",
+        "installer": "v0.14.0-rc.1"
+      }
+    },
+    {
       "version": "v2020.10.27-rc.0",
       "hostDocs": true,
       "show": true,
@@ -265,7 +276,7 @@
       "show": true
     }
   ],
-  "latestVersion": "v2020.10.27-rc.0",
+  "latestVersion": "v2020.10.27-rc.1",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubedb/cli",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.10.27-rc.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/18