### PR TITLE
Update for release KubeDB@v2020.10.27-rc.2

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -163,6 +163,17 @@
       "show": true
     },
     {
+      "version": "v2020.10.27-rc.2",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.14.0-rc.2",
+        "community": "v0.14.0-rc.2",
+        "enterprise": "v0.1.0-rc.2",
+        "installer": "v0.14.0-rc.2"
+      }
+    },
+    {
       "version": "v2020.10.27-rc.1",
       "hostDocs": true,
       "show": true,
@@ -276,7 +287,7 @@
       "show": true
     }
   ],
-  "latestVersion": "v2020.10.27-rc.1",
+  "latestVersion": "v2020.10.27-rc.2",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubedb/cli",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.10.27-rc.2
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/19