### PR TITLE
Update for release KubeDB@v2020.10.28

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -163,6 +163,17 @@
       "show": true
     },
     {
+      "version": "v2020.10.28",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.14.0",
+        "community": "v0.14.0",
+        "enterprise": "v0.1.0",
+        "installer": "v0.14.0"
+      }
+    },
+    {
       "version": "v2020.10.27-rc.2",
       "hostDocs": true,
       "show": true,
@@ -279,7 +290,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2020.10.27-rc.2",
+  "latestVersion": "v2020.10.28",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubedb/cli",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.10.28
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/21