### PR TITLE
Update for release Stash@v2020.10.29

### DIFF
--- a/data/products/stash-cli.json
+++ b/data/products/stash-cli.json
@@ -23,6 +23,55 @@
       "show": true
     },
     {
+      "version": "v0.11.4",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "stash": "v2020.10.29",
+        "stash-catalog": "v2020.10.29",
+        "stash-community": "v0.11.4",
+        "stash-elasticsearch": [
+          "5.6.4-v3",
+          "6.2.4-v3",
+          "6.3.0-v3",
+          "6.4.0-v3",
+          "6.5.3-v3",
+          "6.8.0-v3",
+          "7.2.0-v3",
+          "7.3.2-v3"
+        ],
+        "stash-enterprise": "v0.11.4",
+        "stash-installer": "v0.11.4",
+        "stash-mongodb": [
+          "3.4.17-v3",
+          "3.4.22-v3",
+          "3.6.13-v3",
+          "3.6.8-v3",
+          "4.0.11-v3",
+          "4.0.3-v3",
+          "4.0.5-v3",
+          "4.1.13-v3",
+          "4.1.4-v3",
+          "4.1.7-v3",
+          "4.2.3-v3"
+        ],
+        "stash-mysql": [
+          "5.7.25-v3",
+          "8.0.14-v3",
+          "8.0.3-v3"
+        ],
+        "stash-percona-xtradb": [
+          "5.7-v3"
+        ],
+        "stash-postgres": [
+          "10.14.0-v1",
+          "11.9.0-v1",
+          "12.4.0-v1",
+          "9.6.19-v1"
+        ]
+      }
+    },
+    {
       "version": "v0.11.3",
       "hostDocs": true,
       "show": true,
@@ -130,5 +179,5 @@
       "show": true
     }
   ],
-  "latestVersion": "v0.11.3"
+  "latestVersion": "v0.11.4"
 }

--- a/data/products/stash.json
+++ b/data/products/stash.json
@@ -299,6 +299,55 @@
       "show": true
     },
     {
+      "version": "v2020.10.29",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "catalog": "v2020.10.29",
+        "cli": "v0.11.4",
+        "community": "v0.11.4",
+        "elasticsearch": [
+          "5.6.4-v3",
+          "6.2.4-v3",
+          "6.3.0-v3",
+          "6.4.0-v3",
+          "6.5.3-v3",
+          "6.8.0-v3",
+          "7.2.0-v3",
+          "7.3.2-v3"
+        ],
+        "enterprise": "v0.11.4",
+        "installer": "v0.11.4",
+        "mongodb": [
+          "3.4.17-v3",
+          "3.4.22-v3",
+          "3.6.13-v3",
+          "3.6.8-v3",
+          "4.0.11-v3",
+          "4.0.3-v3",
+          "4.0.5-v3",
+          "4.1.13-v3",
+          "4.1.4-v3",
+          "4.1.7-v3",
+          "4.2.3-v3"
+        ],
+        "mysql": [
+          "5.7.25-v3",
+          "8.0.14-v3",
+          "8.0.3-v3"
+        ],
+        "percona-xtradb": [
+          "5.7-v3"
+        ],
+        "postgres": [
+          "10.14.0-v1",
+          "11.9.0-v1",
+          "12.4.0-v1",
+          "9.6.19-v1"
+        ]
+      }
+    },
+    {
       "version": "v2020.10.21",
       "hostDocs": true,
       "show": true,
@@ -606,7 +655,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2020.10.21",
+  "latestVersion": "v2020.10.29",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/stashed/stash",
@@ -683,7 +732,8 @@
       "mappings": [
         {
           "versions": [
-            "v2020.10.21"
+            "v2020.10.21",
+            "v2020.10.29"
           ],
           "subProjectVersions": [
             "5.6.4-v3",
@@ -827,7 +877,8 @@
       "mappings": [
         {
           "versions": [
-            "v2020.10.21"
+            "v2020.10.21",
+            "v2020.10.29"
           ],
           "subProjectVersions": [
             "3.4.17-v3",
@@ -998,7 +1049,8 @@
       "mappings": [
         {
           "versions": [
-            "v2020.10.21"
+            "v2020.10.21",
+            "v2020.10.29"
           ],
           "subProjectVersions": [
             "5.7.25-v3",
@@ -1097,7 +1149,8 @@
       "mappings": [
         {
           "versions": [
-            "v2020.10.21"
+            "v2020.10.21",
+            "v2020.10.29"
           ],
           "subProjectVersions": [
             "5.7-v3"
@@ -1176,7 +1229,8 @@
       "mappings": [
         {
           "versions": [
-            "v2020.10.21"
+            "v2020.10.21",
+            "v2020.10.29"
           ],
           "subProjectVersions": [
             "9.6.19-v1",


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.10.29
Release-tracker: https://github.com/stashed/CHANGELOG/pull/21