### PR TITLE
Update for release Stash@v2020.10.30

### DIFF
--- a/data/products/stash-cli.json
+++ b/data/products/stash-cli.json
@@ -23,6 +23,55 @@
       "show": true
     },
     {
+      "version": "v0.11.5",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "stash": "v2020.10.30",
+        "stash-catalog": "v2020.10.30",
+        "stash-community": "v0.11.5",
+        "stash-elasticsearch": [
+          "5.6.4-v3",
+          "6.2.4-v3",
+          "6.3.0-v3",
+          "6.4.0-v3",
+          "6.5.3-v3",
+          "6.8.0-v3",
+          "7.2.0-v3",
+          "7.3.2-v3"
+        ],
+        "stash-enterprise": "v0.11.5",
+        "stash-installer": "v0.11.5",
+        "stash-mongodb": [
+          "3.4.17-v3",
+          "3.4.22-v3",
+          "3.6.13-v3",
+          "3.6.8-v3",
+          "4.0.11-v3",
+          "4.0.3-v3",
+          "4.0.5-v3",
+          "4.1.13-v3",
+          "4.1.4-v3",
+          "4.1.7-v3",
+          "4.2.3-v3"
+        ],
+        "stash-mysql": [
+          "5.7.25-v3",
+          "8.0.14-v3",
+          "8.0.3-v3"
+        ],
+        "stash-percona-xtradb": [
+          "5.7-v3"
+        ],
+        "stash-postgres": [
+          "10.14.0-v1",
+          "11.9.0-v1",
+          "12.4.0-v1",
+          "9.6.19-v1"
+        ]
+      }
+    },
+    {
       "version": "v0.11.4",
       "hostDocs": true,
       "show": true,
@@ -179,5 +228,5 @@
       "show": true
     }
   ],
-  "latestVersion": "v0.11.4"
+  "latestVersion": "v0.11.5"
 }

--- a/data/products/stash.json
+++ b/data/products/stash.json
@@ -299,6 +299,55 @@
       "show": true
     },
     {
+      "version": "v2020.10.30",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "catalog": "v2020.10.30",
+        "cli": "v0.11.5",
+        "community": "v0.11.5",
+        "elasticsearch": [
+          "5.6.4-v3",
+          "6.2.4-v3",
+          "6.3.0-v3",
+          "6.4.0-v3",
+          "6.5.3-v3",
+          "6.8.0-v3",
+          "7.2.0-v3",
+          "7.3.2-v3"
+        ],
+        "enterprise": "v0.11.5",
+        "installer": "v0.11.5",
+        "mongodb": [
+          "3.4.17-v3",
+          "3.4.22-v3",
+          "3.6.13-v3",
+          "3.6.8-v3",
+          "4.0.11-v3",
+          "4.0.3-v3",
+          "4.0.5-v3",
+          "4.1.13-v3",
+          "4.1.4-v3",
+          "4.1.7-v3",
+          "4.2.3-v3"
+        ],
+        "mysql": [
+          "5.7.25-v3",
+          "8.0.14-v3",
+          "8.0.3-v3"
+        ],
+        "percona-xtradb": [
+          "5.7-v3"
+        ],
+        "postgres": [
+          "10.14.0-v1",
+          "11.9.0-v1",
+          "12.4.0-v1",
+          "9.6.19-v1"
+        ]
+      }
+    },
+    {
       "version": "v2020.10.29",
       "hostDocs": true,
       "show": true,
@@ -655,7 +704,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2020.10.29",
+  "latestVersion": "v2020.10.30",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/stashed/stash",
@@ -733,7 +782,8 @@
         {
           "versions": [
             "v2020.10.21",
-            "v2020.10.29"
+            "v2020.10.29",
+            "v2020.10.30"
           ],
           "subProjectVersions": [
             "5.6.4-v3",
@@ -878,7 +928,8 @@
         {
           "versions": [
             "v2020.10.21",
-            "v2020.10.29"
+            "v2020.10.29",
+            "v2020.10.30"
           ],
           "subProjectVersions": [
             "3.4.17-v3",
@@ -1050,7 +1101,8 @@
         {
           "versions": [
             "v2020.10.21",
-            "v2020.10.29"
+            "v2020.10.29",
+            "v2020.10.30"
           ],
           "subProjectVersions": [
             "5.7.25-v3",
@@ -1150,7 +1202,8 @@
         {
           "versions": [
             "v2020.10.21",
-            "v2020.10.29"
+            "v2020.10.29",
+            "v2020.10.30"
           ],
           "subProjectVersions": [
             "5.7-v3"
@@ -1230,7 +1283,8 @@
         {
           "versions": [
             "v2020.10.21",
-            "v2020.10.29"
+            "v2020.10.29",
+            "v2020.10.30"
           ],
           "subProjectVersions": [
             "9.6.19-v1",


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.10.30
Release-tracker: https://github.com/stashed/CHANGELOG/pull/22