### PR TITLE
Update for release Stash@v2020.11.06

### DIFF
--- a/data/products/stash-cli.json
+++ b/data/products/stash-cli.json
@@ -23,6 +23,55 @@
       "show": true
     },
     {
+      "version": "v0.11.6",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "stash": "v2020.11.06",
+        "stash-catalog": "v2020.11.06",
+        "stash-community": "v0.11.6",
+        "stash-elasticsearch": [
+          "5.6.4-v4",
+          "6.2.4-v4",
+          "6.3.0-v4",
+          "6.4.0-v4",
+          "6.5.3-v4",
+          "6.8.0-v4",
+          "7.2.0-v4",
+          "7.3.2-v4"
+        ],
+        "stash-enterprise": "v0.11.6",
+        "stash-installer": "v0.11.6",
+        "stash-mongodb": [
+          "3.4.17-v4",
+          "3.4.22-v4",
+          "3.6.13-v4",
+          "3.6.8-v4",
+          "4.0.11-v4",
+          "4.0.3-v4",
+          "4.0.5-v4",
+          "4.1.13-v4",
+          "4.1.4-v4",
+          "4.1.7-v4",
+          "4.2.3-v4"
+        ],
+        "stash-mysql": [
+          "5.7.25-v4",
+          "8.0.14-v4",
+          "8.0.3-v4"
+        ],
+        "stash-percona-xtradb": [
+          "5.7-v4"
+        ],
+        "stash-postgres": [
+          "10.14.0-v2",
+          "11.9.0-v2",
+          "12.4.0-v2",
+          "9.6.19-v2"
+        ]
+      }
+    },
+    {
       "version": "v0.11.5",
       "hostDocs": true,
       "show": true,
@@ -228,5 +277,5 @@
       "show": true
     }
   ],
-  "latestVersion": "v0.11.5"
+  "latestVersion": "v0.11.6"
 }

--- a/data/products/stash-elasticsearch.json
+++ b/data/products/stash-elasticsearch.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "7.3.2-v4",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "7.3.2-v3",
       "hostDocs": true,
       "show": true
@@ -68,6 +73,11 @@
     {
       "version": "7.3.2-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "7.2.0-v4",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "7.2.0-v3",
@@ -112,6 +122,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.8.0-v4",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.8.0-v3",
       "hostDocs": true,
       "show": true
@@ -152,6 +167,11 @@
     {
       "version": "6.8.0-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "6.5.3-v4",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "6.5.3-v3",
@@ -196,6 +216,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.4.0-v4",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.4.0-v3",
       "hostDocs": true,
       "show": true
@@ -236,6 +261,11 @@
     {
       "version": "6.4.0-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "6.3.0-v4",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "6.3.0-v3",
@@ -280,6 +310,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.2.4-v4",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.2.4-v3",
       "hostDocs": true,
       "show": true
@@ -320,6 +355,11 @@
     {
       "version": "6.2.4-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "5.6.4-v4",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "5.6.4-v3",
@@ -364,5 +404,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "7.3.2-v3"
+  "latestVersion": "7.3.2-v4"
 }

--- a/data/products/stash-mongodb.json
+++ b/data/products/stash-mongodb.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "4.2.3-v4",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.2.3-v3",
       "hostDocs": true,
       "show": true
@@ -70,6 +75,11 @@
       "hostDocs": true
     },
     {
+      "version": "4.1.13-v4",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.1.13-v3",
       "hostDocs": true,
       "show": true
@@ -86,6 +96,11 @@
     },
     {
       "version": "4.1.13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.1.7-v4",
       "hostDocs": true,
       "show": true
     },
@@ -130,6 +145,11 @@
     {
       "version": "4.1.7-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "4.1.4-v4",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "4.1.4-v3",
@@ -196,6 +216,11 @@
       "hostDocs": true
     },
     {
+      "version": "4.0.11-v4",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.0.11-v3",
       "hostDocs": true,
       "show": true
@@ -222,6 +247,11 @@
     },
     {
       "version": "4.0.11-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.0.5-v4",
       "hostDocs": true,
       "show": true
     },
@@ -266,6 +296,11 @@
     {
       "version": "4.0.5-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "4.0.3-v4",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "4.0.3-v3",
@@ -322,6 +357,11 @@
       "hostDocs": true
     },
     {
+      "version": "3.6.13-v4",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.6.13-v3",
       "hostDocs": true,
       "show": true
@@ -338,6 +378,11 @@
     },
     {
       "version": "3.6.13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "3.6.8-v4",
       "hostDocs": true,
       "show": true
     },
@@ -406,6 +451,11 @@
       "hostDocs": true
     },
     {
+      "version": "3.4.22-v4",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.4.22-v3",
       "hostDocs": true,
       "show": true
@@ -422,6 +472,11 @@
     },
     {
       "version": "3.4.22",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "3.4.17-v4",
       "hostDocs": true,
       "show": true
     },
@@ -490,5 +545,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "4.2.3-v3"
+  "latestVersion": "4.2.3-v4"
 }

--- a/data/products/stash-mysql.json
+++ b/data/products/stash-mysql.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "8.0.14-v4",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "8.0.14-v3",
       "hostDocs": true,
       "show": true
@@ -68,6 +73,11 @@
     {
       "version": "8.0.14-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "8.0.3-v4",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "8.0.3-v3",
@@ -112,6 +122,11 @@
       "hostDocs": true
     },
     {
+      "version": "5.7.25-v4",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "5.7.25-v3",
       "hostDocs": true,
       "show": true
@@ -154,5 +169,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "8.0.14-v3"
+  "latestVersion": "8.0.14-v4"
 }

--- a/data/products/stash-percona-xtradb.json
+++ b/data/products/stash-percona-xtradb.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "5.7-v4",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "5.7-v3",
       "hostDocs": true,
       "show": true
@@ -70,5 +75,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "5.7-v3"
+  "latestVersion": "5.7-v4"
 }

--- a/data/products/stash-postgres.json
+++ b/data/products/stash-postgres.json
@@ -28,12 +28,22 @@
       "show": true
     },
     {
+      "version": "12.4.0-v2",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "12.4.0-v1",
       "hostDocs": true,
       "show": true
     },
     {
       "version": "12.4.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "11.9.0-v2",
       "hostDocs": true,
       "show": true
     },
@@ -112,6 +122,11 @@
       "hostDocs": true
     },
     {
+      "version": "10.14.0-v2",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "10.14.0-v1",
       "hostDocs": true,
       "show": true
@@ -186,6 +201,11 @@
       "hostDocs": true
     },
     {
+      "version": "9.6.19-v2",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "9.6.19-v1",
       "hostDocs": true,
       "show": true
@@ -228,5 +248,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "12.4.0-v1"
+  "latestVersion": "12.4.0-v2"
 }

--- a/data/products/stash.json
+++ b/data/products/stash.json
@@ -299,6 +299,55 @@
       "show": true
     },
     {
+      "version": "v2020.11.06",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "catalog": "v2020.11.06",
+        "cli": "v0.11.6",
+        "community": "v0.11.6",
+        "elasticsearch": [
+          "5.6.4-v4",
+          "6.2.4-v4",
+          "6.3.0-v4",
+          "6.4.0-v4",
+          "6.5.3-v4",
+          "6.8.0-v4",
+          "7.2.0-v4",
+          "7.3.2-v4"
+        ],
+        "enterprise": "v0.11.6",
+        "installer": "v0.11.6",
+        "mongodb": [
+          "3.4.17-v4",
+          "3.4.22-v4",
+          "3.6.13-v4",
+          "3.6.8-v4",
+          "4.0.11-v4",
+          "4.0.3-v4",
+          "4.0.5-v4",
+          "4.1.13-v4",
+          "4.1.4-v4",
+          "4.1.7-v4",
+          "4.2.3-v4"
+        ],
+        "mysql": [
+          "5.7.25-v4",
+          "8.0.14-v4",
+          "8.0.3-v4"
+        ],
+        "percona-xtradb": [
+          "5.7-v4"
+        ],
+        "postgres": [
+          "10.14.0-v2",
+          "11.9.0-v2",
+          "12.4.0-v2",
+          "9.6.19-v2"
+        ]
+      }
+    },
+    {
       "version": "v2020.10.30",
       "hostDocs": true,
       "show": true,
@@ -704,7 +753,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2020.10.30",
+  "latestVersion": "v2020.11.06",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/stashed/stash",
@@ -779,6 +828,21 @@
     "stash-elasticsearch": {
       "dir": "addons/elasticsearch/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2020.11.06"
+          ],
+          "subProjectVersions": [
+            "5.6.4-v4",
+            "6.2.4-v4",
+            "6.3.0-v4",
+            "6.4.0-v4",
+            "6.5.3-v4",
+            "6.8.0-v4",
+            "7.2.0-v4",
+            "7.3.2-v4"
+          ]
+        },
         {
           "versions": [
             "v2020.10.21",
@@ -925,6 +989,24 @@
     "stash-mongodb": {
       "dir": "addons/mongodb/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2020.11.06"
+          ],
+          "subProjectVersions": [
+            "3.4.17-v4",
+            "3.4.22-v4",
+            "3.6.8-v4",
+            "3.6.13-v4",
+            "4.0.3-v4",
+            "4.0.5-v4",
+            "4.0.11-v4",
+            "4.1.4-v4",
+            "4.1.7-v4",
+            "4.1.13-v4",
+            "4.2.3-v4"
+          ]
+        },
         {
           "versions": [
             "v2020.10.21",
@@ -1100,6 +1182,16 @@
       "mappings": [
         {
           "versions": [
+            "v2020.11.06"
+          ],
+          "subProjectVersions": [
+            "5.7.25-v4",
+            "8.0.3-v4",
+            "8.0.14-v4"
+          ]
+        },
+        {
+          "versions": [
             "v2020.10.21",
             "v2020.10.29",
             "v2020.10.30"
@@ -1201,6 +1293,14 @@
       "mappings": [
         {
           "versions": [
+            "v2020.11.06"
+          ],
+          "subProjectVersions": [
+            "5.7-v4"
+          ]
+        },
+        {
+          "versions": [
             "v2020.10.21",
             "v2020.10.29",
             "v2020.10.30"
@@ -1280,6 +1380,17 @@
     "stash-postgres": {
       "dir": "addons/postgres/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2020.11.06"
+          ],
+          "subProjectVersions": [
+            "9.6.19-v2",
+            "10.14.0-v2",
+            "11.9.0-v2",
+            "12.4.0-v2"
+          ]
+        },
         {
           "versions": [
             "v2020.10.21",


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.11.06
Release-tracker: https://github.com/stashed/CHANGELOG/pull/23