### PR TITLE
Update for release KubeDB@v2020.11.11

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -163,6 +163,17 @@
       "show": true
     },
     {
+      "version": "v2020.11.11",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.15.0",
+        "community": "v0.15.0",
+        "enterprise": "v0.2.0",
+        "installer": "v0.15.0"
+      }
+    },
+    {
       "version": "v2020.11.08",
       "hostDocs": true,
       "show": true,
@@ -300,7 +311,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2020.11.08",
+  "latestVersion": "v2020.11.11",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubedb/cli",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.11.11
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/23