### PR TITLE
Update for release KubeDB@v2020.11.12

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -163,6 +163,17 @@
       "show": true
     },
     {
+      "version": "v2020.11.12",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.15.1",
+        "community": "v0.15.1",
+        "enterprise": "v0.2.1",
+        "installer": "v0.15.1"
+      }
+    },
+    {
       "version": "v2020.11.11",
       "hostDocs": true,
       "show": true,
@@ -311,7 +322,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2020.11.11",
+  "latestVersion": "v2020.11.12",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubedb/cli",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.11.12
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/24