### PR TITLE
Update for release KubeDB@v2020.12.10

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -163,6 +163,17 @@
       "show": true
     },
     {
+      "version": "v2020.12.10",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.15.2",
+        "community": "v0.15.2",
+        "enterprise": "v0.2.2",
+        "installer": "v0.15.2"
+      }
+    },
+    {
       "version": "v2020.11.12",
       "hostDocs": true,
       "show": true,
@@ -322,7 +333,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2020.11.12",
+  "latestVersion": "v2020.12.10",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubedb/cli",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.12.10
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/26