### PR TITLE
Update for release KubeDB@v2021.01.14

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -163,6 +163,18 @@
       "show": true
     },
     {
+      "version": "v2021.01.14",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "autocaler": "v0.1.0",
+        "cli": "v0.16.0",
+        "community": "v0.16.0",
+        "enterprise": "v0.3.0",
+        "installer": "v0.16.0"
+      }
+    },
+    {
       "version": "v2021.01.02-rc.0",
       "hostDocs": true,
       "show": true,
@@ -346,7 +358,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2021.01.02-rc.0",
+  "latestVersion": "v2021.01.14",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubedb/cli",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.01.14
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/29