### PR TITLE
Update for release KubeDB@v2021.01.15

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -163,6 +163,18 @@
       "show": true
     },
     {
+      "version": "v2021.01.15",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "autoscaler": "v0.1.1",
+        "cli": "v0.16.1",
+        "community": "v0.16.1",
+        "enterprise": "v0.3.1",
+        "installer": "v0.16.1"
+      }
+    },
+    {
       "version": "v2021.01.14",
       "hostDocs": true,
       "show": true,
@@ -358,7 +370,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2021.01.14",
+  "latestVersion": "v2021.01.15",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubedb/cli",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.01.15
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/30