### PR TITLE
Update for release Stash@v2021.01.21

### DIFF
--- a/data/products/stash-cli.json
+++ b/data/products/stash-cli.json
@@ -23,6 +23,60 @@
       "show": true
     },
     {
+      "version": "v0.11.9",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "stash": "v2021.01.21",
+        "stash-catalog": "v2021.01.21",
+        "stash-community": "v0.11.9",
+        "stash-elasticsearch": [
+          "5.6.4-v6",
+          "6.2.4-v6",
+          "6.3.0-v6",
+          "6.4.0-v6",
+          "6.5.3-v6",
+          "6.8.0-v6",
+          "7.2.0-v6",
+          "7.3.2-v6"
+        ],
+        "stash-enterprise": "v0.11.9",
+        "stash-installer": "v0.11.9",
+        "stash-mariadb": [
+          "10.5.8"
+        ],
+        "stash-mongodb": [
+          "3.4.17-v5",
+          "3.4.22-v5",
+          "3.6.13-v5",
+          "3.6.8-v5",
+          "4.0.11-v5",
+          "4.0.3-v5",
+          "4.0.5-v5",
+          "4.1.13-v5",
+          "4.1.4-v5",
+          "4.1.7-v5",
+          "4.2.3-v5"
+        ],
+        "stash-mysql": [
+          "5.7.25-v6",
+          "8.0.14-v6",
+          "8.0.21",
+          "8.0.3-v6"
+        ],
+        "stash-percona-xtradb": [
+          "5.7.0-v1"
+        ],
+        "stash-postgres": [
+          "10.14.0-v4",
+          "11.9.0-v4",
+          "12.4.0-v4",
+          "13.1.0-v1",
+          "9.6.19-v4"
+        ]
+      }
+    },
+    {
       "version": "v0.11.8",
       "hostDocs": true,
       "show": true,
@@ -380,5 +434,5 @@
       "show": true
     }
   ],
-  "latestVersion": "v0.11.8"
+  "latestVersion": "v0.11.9"
 }

--- a/data/products/stash-elasticsearch.json
+++ b/data/products/stash-elasticsearch.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "7.3.2-v6",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "7.3.2-v5",
       "hostDocs": true,
       "show": true
@@ -78,6 +83,11 @@
     {
       "version": "7.3.2-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "7.2.0-v6",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "7.2.0-v5",
@@ -132,6 +142,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.8.0-v6",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.8.0-v5",
       "hostDocs": true,
       "show": true
@@ -182,6 +197,11 @@
     {
       "version": "6.8.0-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "6.5.3-v6",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "6.5.3-v5",
@@ -236,6 +256,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.4.0-v6",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.4.0-v5",
       "hostDocs": true,
       "show": true
@@ -286,6 +311,11 @@
     {
       "version": "6.4.0-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "6.3.0-v6",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "6.3.0-v5",
@@ -340,6 +370,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.2.4-v6",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.2.4-v5",
       "hostDocs": true,
       "show": true
@@ -390,6 +425,11 @@
     {
       "version": "6.2.4-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "5.6.4-v6",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "5.6.4-v5",
@@ -444,5 +484,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "7.3.2-v5"
+  "latestVersion": "7.3.2-v6"
 }

--- a/data/products/stash-mysql.json
+++ b/data/products/stash-mysql.json
@@ -28,6 +28,16 @@
       "show": true
     },
     {
+      "version": "8.0.21",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "8.0.14-v6",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "8.0.14-v5",
       "hostDocs": true,
       "show": true
@@ -78,6 +88,11 @@
     {
       "version": "8.0.14-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "8.0.3-v6",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "8.0.3-v5",
@@ -132,6 +147,11 @@
       "hostDocs": true
     },
     {
+      "version": "5.7.25-v6",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "5.7.25-v5",
       "hostDocs": true,
       "show": true
@@ -184,5 +204,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "8.0.14-v5"
+  "latestVersion": "8.0.21"
 }

--- a/data/products/stash-percona-xtradb.json
+++ b/data/products/stash-percona-xtradb.json
@@ -43,22 +43,22 @@
       "show": true
     },
     {
-      "version": "5.7.0-v1",
-      "hostDocs": true,
-      "show": true
-    },
-    {
       "version": "5.7-v1",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "5.7.0",
+      "version": "5.7.0-v1",
       "hostDocs": true,
       "show": true
     },
     {
       "version": "5.7",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "5.7.0",
       "hostDocs": true,
       "show": true
     },

--- a/data/products/stash.json
+++ b/data/products/stash.json
@@ -299,6 +299,60 @@
       "show": true
     },
     {
+      "version": "v2021.01.21",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "catalog": "v2021.01.21",
+        "cli": "v0.11.9",
+        "community": "v0.11.9",
+        "elasticsearch": [
+          "5.6.4-v6",
+          "6.2.4-v6",
+          "6.3.0-v6",
+          "6.4.0-v6",
+          "6.5.3-v6",
+          "6.8.0-v6",
+          "7.2.0-v6",
+          "7.3.2-v6"
+        ],
+        "enterprise": "v0.11.9",
+        "installer": "v0.11.9",
+        "mariadb": [
+          "10.5.8"
+        ],
+        "mongodb": [
+          "3.4.17-v5",
+          "3.4.22-v5",
+          "3.6.13-v5",
+          "3.6.8-v5",
+          "4.0.11-v5",
+          "4.0.3-v5",
+          "4.0.5-v5",
+          "4.1.13-v5",
+          "4.1.4-v5",
+          "4.1.7-v5",
+          "4.2.3-v5"
+        ],
+        "mysql": [
+          "5.7.25-v6",
+          "8.0.14-v6",
+          "8.0.21",
+          "8.0.3-v6"
+        ],
+        "percona-xtradb": [
+          "5.7.0-v1"
+        ],
+        "postgres": [
+          "10.14.0-v4",
+          "11.9.0-v4",
+          "12.4.0-v4",
+          "13.1.0-v1",
+          "9.6.19-v4"
+        ]
+      }
+    },
+    {
       "version": "v2020.12.17",
       "hostDocs": true,
       "show": true,
@@ -856,7 +910,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2020.12.17",
+  "latestVersion": "v2021.01.21",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/stashed/stash",
@@ -931,6 +985,21 @@
     "stash-elasticsearch": {
       "dir": "addons/elasticsearch/guides",
       "mappings": [
+        {
+          "versions": [
+            "v2021.01.21"
+          ],
+          "subProjectVersions": [
+            "5.6.4-v6",
+            "6.2.4-v6",
+            "6.3.0-v6",
+            "6.4.0-v6",
+            "6.5.3-v6",
+            "6.8.0-v6",
+            "7.2.0-v6",
+            "7.3.2-v6"
+          ]
+        },
         {
           "versions": [
             "v2020.12.17"
@@ -1110,7 +1179,8 @@
       "mappings": [
         {
           "versions": [
-            "v2020.12.17"
+            "v2020.12.17",
+            "v2021.01.21"
           ],
           "subProjectVersions": [
             "10.5.8"
@@ -1123,7 +1193,8 @@
       "mappings": [
         {
           "versions": [
-            "v2020.12.17"
+            "v2020.12.17",
+            "v2021.01.21"
           ],
           "subProjectVersions": [
             "3.4.17-v5",
@@ -1333,6 +1404,17 @@
       "mappings": [
         {
           "versions": [
+            "v2021.01.21"
+          ],
+          "subProjectVersions": [
+            "5.7.25-v6",
+            "8.0.3-v6",
+            "8.0.14-v6",
+            "8.0.21"
+          ]
+        },
+        {
+          "versions": [
             "v2020.12.17"
           ],
           "subProjectVersions": [
@@ -1455,7 +1537,8 @@
       "mappings": [
         {
           "versions": [
-            "v2020.12.17"
+            "v2020.12.17",
+            "v2021.01.21"
           ],
           "subProjectVersions": [
             "5.7.0-v1"
@@ -1560,7 +1643,8 @@
       "mappings": [
         {
           "versions": [
-            "v2020.12.17"
+            "v2020.12.17",
+            "v2021.01.21"
           ],
           "subProjectVersions": [
             "9.6.19-v4",


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.01.21
Release-tracker: https://github.com/stashed/CHANGELOG/pull/27