### PR TITLE
Update for release KubeDB@v2021.03.11

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -163,6 +163,19 @@
       "show": true
     },
     {
+      "version": "v2021.03.11",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "autoscaler": "v0.2.0",
+        "cli": "v0.17.0",
+        "community": "v0.17.0",
+        "enterprise": "v0.4.0",
+        "installer": "v0.17.0",
+        "release": "v2021.03.11"
+      }
+    },
+    {
       "version": "v2021.01.26",
       "hostDocs": true,
       "show": true,
@@ -381,7 +394,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2021.01.26",
+  "latestVersion": "v2021.03.11",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubedb/cli",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.03.11
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/34