### PR TITLE
Update for release KubeDB@v2021.03.17

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -163,6 +163,18 @@
       "show": true
     },
     {
+      "version": "v2021.03.17",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "autoscaler": "v0.2.1",
+        "cli": "v0.17.1",
+        "community": "v0.17.1",
+        "enterprise": "v0.4.1",
+        "installer": "v0.17.1"
+      }
+    },
+    {
       "version": "v2021.03.11",
       "hostDocs": true,
       "show": true,
@@ -394,7 +406,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2021.03.11",
+  "latestVersion": "v2021.03.17",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubedb/cli",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.03.17
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/35