### PR TITLE
Update for release Stash@v2021.6.18

### DIFF
--- a/data/products/stash-cli.json
+++ b/data/products/stash-cli.json
@@ -23,6 +23,60 @@
       "show": true
     },
     {
+      "version": "v0.14.0",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "stash": "v2021.6.18",
+        "stash-community": "v0.14.0",
+        "stash-elasticsearch": [
+          "5.6.4-v10",
+          "6.2.4-v10",
+          "6.3.0-v10",
+          "6.4.0-v10",
+          "6.5.3-v10",
+          "6.8.0-v10",
+          "7.2.0-v10",
+          "7.3.2-v10"
+        ],
+        "stash-enterprise": "v0.14.0",
+        "stash-installer": "v2021.6.18",
+        "stash-mariadb": [
+          "10.5.8-v3"
+        ],
+        "stash-mongodb": [
+          "3.4.17-v9",
+          "3.4.22-v9",
+          "3.6.13-v9",
+          "3.6.8-v9",
+          "4.0.11-v9",
+          "4.0.3-v9",
+          "4.0.5-v9",
+          "4.1.13-v9",
+          "4.1.4-v9",
+          "4.1.7-v9",
+          "4.2.3-v9",
+          "4.4.6"
+        ],
+        "stash-mysql": [
+          "5.7.25-v10",
+          "8.0.14-v10",
+          "8.0.21-v4",
+          "8.0.3-v10"
+        ],
+        "stash-percona-xtradb": [
+          "5.7-v5"
+        ],
+        "stash-postgres": [
+          "10.14-v8",
+          "11.9-v8",
+          "12.4-v8",
+          "13.1-v5",
+          "9.6.19-v8"
+        ]
+      }
+    },
+    {
       "version": "v0.12.3",
       "hostDocs": true,
       "show": true,
@@ -754,5 +808,5 @@
       "show": true
     }
   ],
-  "latestVersion": "v0.12.3"
+  "latestVersion": "v0.14.0"
 }

--- a/data/products/stash-elasticsearch.json
+++ b/data/products/stash-elasticsearch.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "7.3.2-v10",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "7.3.2-v9",
       "hostDocs": true,
       "show": true
@@ -98,6 +103,11 @@
     {
       "version": "7.3.2-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "7.2.0-v10",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "7.2.0-v9",
@@ -172,6 +182,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.8.0-v10",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.8.0-v9",
       "hostDocs": true,
       "show": true
@@ -242,6 +257,11 @@
     {
       "version": "6.8.0-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "6.5.3-v10",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "6.5.3-v9",
@@ -316,6 +336,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.4.0-v10",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.4.0-v9",
       "hostDocs": true,
       "show": true
@@ -386,6 +411,11 @@
     {
       "version": "6.4.0-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "6.3.0-v10",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "6.3.0-v9",
@@ -460,6 +490,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.2.4-v10",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.2.4-v9",
       "hostDocs": true,
       "show": true
@@ -530,6 +565,11 @@
     {
       "version": "6.2.4-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "5.6.4-v10",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "5.6.4-v9",
@@ -604,5 +644,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "7.3.2-v9"
+  "latestVersion": "7.3.2-v10"
 }

--- a/data/products/stash-mongodb.json
+++ b/data/products/stash-mongodb.json
@@ -28,6 +28,16 @@
       "show": true
     },
     {
+      "version": "4.4.6",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.2.3-v9",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.2.3-v8",
       "hostDocs": true,
       "show": true
@@ -95,6 +105,11 @@
       "hostDocs": true
     },
     {
+      "version": "4.1.13-v9",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.1.13-v8",
       "hostDocs": true,
       "show": true
@@ -136,6 +151,11 @@
     },
     {
       "version": "4.1.13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.1.7-v9",
       "hostDocs": true,
       "show": true
     },
@@ -205,6 +225,11 @@
     {
       "version": "4.1.7-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "4.1.4-v9",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "4.1.4-v8",
@@ -296,6 +321,11 @@
       "hostDocs": true
     },
     {
+      "version": "4.0.11-v9",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.0.11-v8",
       "hostDocs": true,
       "show": true
@@ -347,6 +377,11 @@
     },
     {
       "version": "4.0.11-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.0.5-v9",
       "hostDocs": true,
       "show": true
     },
@@ -416,6 +451,11 @@
     {
       "version": "4.0.5-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "4.0.3-v9",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "4.0.3-v8",
@@ -497,6 +537,11 @@
       "hostDocs": true
     },
     {
+      "version": "3.6.13-v9",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.6.13-v8",
       "hostDocs": true,
       "show": true
@@ -538,6 +583,11 @@
     },
     {
       "version": "3.6.13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "3.6.8-v9",
       "hostDocs": true,
       "show": true
     },
@@ -631,6 +681,11 @@
       "hostDocs": true
     },
     {
+      "version": "3.4.22-v9",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.4.22-v8",
       "hostDocs": true,
       "show": true
@@ -672,6 +727,11 @@
     },
     {
       "version": "3.4.22",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "3.4.17-v9",
       "hostDocs": true,
       "show": true
     },
@@ -765,5 +825,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "4.2.3-v8"
+  "latestVersion": "4.4.6"
 }

--- a/data/products/stash-mysql.json
+++ b/data/products/stash-mysql.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "8.0.21-v4",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "8.0.21-v3",
       "hostDocs": true,
       "show": true
@@ -44,6 +49,11 @@
     },
     {
       "version": "8.0.21",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "8.0.14-v10",
       "hostDocs": true,
       "show": true
     },
@@ -120,6 +130,11 @@
       "hostDocs": true
     },
     {
+      "version": "8.0.3-v10",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "8.0.3-v9",
       "hostDocs": true,
       "show": true
@@ -190,6 +205,11 @@
     {
       "version": "8.0.3-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "5.7.25-v10",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "5.7.25-v9",
@@ -264,5 +284,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "8.0.21-v3"
+  "latestVersion": "8.0.21-v4"
 }

--- a/data/products/stash-percona-xtradb.json
+++ b/data/products/stash-percona-xtradb.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "5.7-v5",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "5.7-v4",
       "hostDocs": true,
       "show": true
@@ -38,17 +43,12 @@
       "show": true
     },
     {
-      "version": "5.7.0-v2",
-      "hostDocs": true,
-      "show": true
-    },
-    {
       "version": "5.7-v2",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "5.7.0-v1",
+      "version": "5.7.0-v2",
       "hostDocs": true,
       "show": true
     },
@@ -58,12 +58,17 @@
       "show": true
     },
     {
-      "version": "5.7",
+      "version": "5.7.0-v1",
       "hostDocs": true,
       "show": true
     },
     {
       "version": "5.7.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "5.7",
       "hostDocs": true,
       "show": true
     },
@@ -90,5 +95,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "5.7-v4"
+  "latestVersion": "5.7-v5"
 }

--- a/data/products/stash-postgres.json
+++ b/data/products/stash-postgres.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "13.1-v5",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "13.1-v4",
       "hostDocs": true,
       "show": true
@@ -38,12 +43,12 @@
       "show": true
     },
     {
-      "version": "13.1.0-v2",
+      "version": "13.1-v2",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "13.1-v2",
+      "version": "13.1.0-v2",
       "hostDocs": true,
       "show": true
     },
@@ -58,6 +63,11 @@
       "show": true
     },
     {
+      "version": "12.4-v8",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "12.4-v7",
       "hostDocs": true,
       "show": true
@@ -68,12 +78,12 @@
       "show": true
     },
     {
-      "version": "12.4.0-v5",
+      "version": "12.4-v5",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "12.4-v5",
+      "version": "12.4.0-v5",
       "hostDocs": true,
       "show": true
     },
@@ -103,6 +113,11 @@
       "show": true
     },
     {
+      "version": "11.9-v8",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "11.9-v7",
       "hostDocs": true,
       "show": true
@@ -113,12 +128,12 @@
       "show": true
     },
     {
-      "version": "11.9-v5",
+      "version": "11.9.0-v5",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "11.9.0-v5",
+      "version": "11.9-v5",
       "hostDocs": true,
       "show": true
     },
@@ -212,6 +227,11 @@
       "hostDocs": true
     },
     {
+      "version": "10.14-v8",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "10.14-v7",
       "hostDocs": true,
       "show": true
@@ -222,12 +242,12 @@
       "show": true
     },
     {
-      "version": "10.14-v5",
+      "version": "10.14.0-v5",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "10.14.0-v5",
+      "version": "10.14-v5",
       "hostDocs": true,
       "show": true
     },
@@ -321,6 +341,11 @@
       "hostDocs": true
     },
     {
+      "version": "9.6.19-v8",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "9.6.19-v7",
       "hostDocs": true,
       "show": true
@@ -393,5 +418,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "13.1-v4"
+  "latestVersion": "13.1-v5"
 }

--- a/data/products/stash.json
+++ b/data/products/stash.json
@@ -299,6 +299,60 @@
       "show": true
     },
     {
+      "version": "v2021.6.18",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.14.0",
+        "community": "v0.14.0",
+        "elasticsearch": [
+          "5.6.4-v10",
+          "6.2.4-v10",
+          "6.3.0-v10",
+          "6.4.0-v10",
+          "6.5.3-v10",
+          "6.8.0-v10",
+          "7.2.0-v10",
+          "7.3.2-v10"
+        ],
+        "enterprise": "v0.14.0",
+        "installer": "v2021.6.18",
+        "mariadb": [
+          "10.5.8-v3"
+        ],
+        "mongodb": [
+          "3.4.17-v9",
+          "3.4.22-v9",
+          "3.6.13-v9",
+          "3.6.8-v9",
+          "4.0.11-v9",
+          "4.0.3-v9",
+          "4.0.5-v9",
+          "4.1.13-v9",
+          "4.1.4-v9",
+          "4.1.7-v9",
+          "4.2.3-v9",
+          "4.4.6"
+        ],
+        "mysql": [
+          "5.7.25-v10",
+          "8.0.14-v10",
+          "8.0.21-v4",
+          "8.0.3-v10"
+        ],
+        "percona-xtradb": [
+          "5.7-v5"
+        ],
+        "postgres": [
+          "10.14-v8",
+          "11.9-v8",
+          "12.4-v8",
+          "13.1-v5",
+          "9.6.19-v8"
+        ]
+      }
+    },
+    {
       "version": "v2021.04.12",
       "hostDocs": true,
       "show": true,
@@ -354,7 +408,6 @@
     {
       "version": "v2021.04.09",
       "hostDocs": false,
-      "show": false,
       "info": {
         "cli": "v0.12.2",
         "community": "v0.12.2",
@@ -407,7 +460,6 @@
     {
       "version": "v2021.04.07",
       "hostDocs": false,
-      "show": false,
       "info": {
         "cli": "v0.12.1",
         "community": "v0.12.1",
@@ -1228,7 +1280,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2021.04.12",
+  "latestVersion": "v2021.6.18",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/stashed/stash",


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.6.18
Release-tracker: https://github.com/stashed/CHANGELOG/pull/37