### PR TITLE
Update for release KubeDB@v2021.06.23

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -163,6 +163,18 @@
       "show": true
     },
     {
+      "version": "v2021.06.23",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "autoscaler": "v0.4.0",
+        "cli": "v0.19.0",
+        "community": "v0.19.0",
+        "enterprise": "v0.6.0",
+        "installer": "v2021.06.23"
+      }
+    },
+    {
       "version": "v2021.06.21-rc.0",
       "hostDocs": true,
       "show": true,
@@ -429,7 +441,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2021.06.21-rc.0",
+  "latestVersion": "v2021.06.23",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubedb/cli",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.06.23
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/39