### PR TITLE
Update for release KubeDB@v2021.09.30

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -163,6 +163,18 @@
       "show": true
     },
     {
+      "version": "v2021.09.30",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "autoscaler": "v0.7.0",
+        "cli": "v0.22.0",
+        "community": "v0.22.0",
+        "enterprise": "v0.9.0",
+        "installer": "v2021.09.30"
+      }
+    },
+    {
       "version": "v2021.09.09",
       "hostDocs": true,
       "show": true,
@@ -465,7 +477,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2021.09.09",
+  "latestVersion": "v2021.09.30",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubedb/cli",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.09.30
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/43