### PR TITLE
Update for release Stash@v2021.10.11

### DIFF
--- a/data/products/stash-cli.json
+++ b/data/products/stash-cli.json
@@ -23,6 +23,72 @@
       "show": true
     },
     {
+      "version": "v0.16.0",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "stash": "v2021.10.11",
+        "stash-community": "v0.16.0",
+        "stash-elasticsearch": [
+          "5.6.4-v13",
+          "6.2.4-v13",
+          "6.3.0-v13",
+          "6.4.0-v13",
+          "6.5.3-v13",
+          "6.8.0-v13",
+          "7.2.0-v13",
+          "7.3.2-v13"
+        ],
+        "stash-enterprise": "v0.16.0",
+        "stash-etcd": [
+          "3.5.0"
+        ],
+        "stash-installer": "v2021.10.11",
+        "stash-mariadb": [
+          "10.5.8-v6"
+        ],
+        "stash-mongodb": [
+          "3.4.17-v12",
+          "3.4.22-v12",
+          "3.6.13-v12",
+          "3.6.8-v12",
+          "4.0.11-v12",
+          "4.0.3-v12",
+          "4.0.5-v12",
+          "4.1.13-v12",
+          "4.1.4-v12",
+          "4.1.7-v12",
+          "4.2.3-v12",
+          "4.4.6-v3",
+          "5.0.3"
+        ],
+        "stash-mysql": [
+          "5.7.25-v13",
+          "8.0.14-v13",
+          "8.0.21-v7",
+          "8.0.3-v13"
+        ],
+        "stash-nats": [
+          "2.6.1"
+        ],
+        "stash-percona-xtradb": [
+          "5.7-v8"
+        ],
+        "stash-postgres": [
+          "10.14-v11",
+          "11.9-v11",
+          "12.4-v11",
+          "13.1-v8",
+          "14.0",
+          "9.6.19-v11"
+        ],
+        "stash-redis": [
+          "5.0.13-v1",
+          "6.2.5-v1"
+        ]
+      }
+    },
+    {
       "version": "v0.15.0",
       "hostDocs": true,
       "show": true,
@@ -920,5 +986,5 @@
       "show": true
     }
   ],
-  "latestVersion": "v0.15.0"
+  "latestVersion": "v0.16.0"
 }

--- a/data/products/stash-elasticsearch.json
+++ b/data/products/stash-elasticsearch.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "7.3.2-v13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "7.3.2-v12",
       "hostDocs": true,
       "show": true
@@ -113,6 +118,11 @@
     {
       "version": "7.3.2-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "7.2.0-v13",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "7.2.0-v12",
@@ -202,6 +212,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.8.0-v13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.8.0-v12",
       "hostDocs": true,
       "show": true
@@ -287,6 +302,11 @@
     {
       "version": "6.8.0-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "6.5.3-v13",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "6.5.3-v12",
@@ -376,6 +396,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.4.0-v13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.4.0-v12",
       "hostDocs": true,
       "show": true
@@ -461,6 +486,11 @@
     {
       "version": "6.4.0-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "6.3.0-v13",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "6.3.0-v12",
@@ -550,6 +580,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.2.4-v13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.2.4-v12",
       "hostDocs": true,
       "show": true
@@ -635,6 +670,11 @@
     {
       "version": "6.2.4-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "5.6.4-v13",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "5.6.4-v12",
@@ -724,5 +764,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "7.3.2-v12"
+  "latestVersion": "7.3.2-v13"
 }

--- a/data/products/stash-etcd.json
+++ b/data/products/stash-etcd.json
@@ -26,7 +26,12 @@
       "version": "master",
       "hostDocs": false,
       "show": true
+    },
+    {
+      "version": "3.5.0",
+      "hostDocs": true,
+      "show": true
     }
   ],
-  "latestVersion": "master"
+  "latestVersion": "3.5.0"
 }

--- a/data/products/stash-mariadb.json
+++ b/data/products/stash-mariadb.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "10.5.8-v6",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "10.5.8-v5",
       "hostDocs": true,
       "show": true
@@ -58,5 +63,5 @@
       "show": true
     }
   ],
-  "latestVersion": "10.5.8-v5"
+  "latestVersion": "10.5.8-v6"
 }

--- a/data/products/stash-mongodb.json
+++ b/data/products/stash-mongodb.json
@@ -28,6 +28,16 @@
       "show": true
     },
     {
+      "version": "5.0.3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.4.6-v3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.4.6-v2",
       "hostDocs": true,
       "show": true
@@ -39,6 +49,11 @@
     },
     {
       "version": "4.4.6",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.2.3-v12",
       "hostDocs": true,
       "show": true
     },
@@ -125,6 +140,11 @@
       "hostDocs": true
     },
     {
+      "version": "4.1.13-v12",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.1.13-v11",
       "hostDocs": true,
       "show": true
@@ -181,6 +201,11 @@
     },
     {
       "version": "4.1.13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.1.7-v12",
       "hostDocs": true,
       "show": true
     },
@@ -265,6 +290,11 @@
     {
       "version": "4.1.7-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "4.1.4-v12",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "4.1.4-v11",
@@ -371,6 +401,11 @@
       "hostDocs": true
     },
     {
+      "version": "4.0.11-v12",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.0.11-v11",
       "hostDocs": true,
       "show": true
@@ -437,6 +472,11 @@
     },
     {
       "version": "4.0.11-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.0.5-v12",
       "hostDocs": true,
       "show": true
     },
@@ -521,6 +561,11 @@
     {
       "version": "4.0.5-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "4.0.3-v12",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "4.0.3-v11",
@@ -617,6 +662,11 @@
       "hostDocs": true
     },
     {
+      "version": "3.6.13-v12",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.6.13-v11",
       "hostDocs": true,
       "show": true
@@ -673,6 +723,11 @@
     },
     {
       "version": "3.6.13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "3.6.8-v12",
       "hostDocs": true,
       "show": true
     },
@@ -781,6 +836,11 @@
       "hostDocs": true
     },
     {
+      "version": "3.4.22-v12",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.4.22-v11",
       "hostDocs": true,
       "show": true
@@ -837,6 +897,11 @@
     },
     {
       "version": "3.4.22",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "3.4.17-v12",
       "hostDocs": true,
       "show": true
     },
@@ -945,5 +1010,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "4.4.6-v2"
+  "latestVersion": "5.0.3"
 }

--- a/data/products/stash-mysql.json
+++ b/data/products/stash-mysql.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "8.0.21-v7",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "8.0.21-v6",
       "hostDocs": true,
       "show": true
@@ -59,6 +64,11 @@
     },
     {
       "version": "8.0.21",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "8.0.14-v13",
       "hostDocs": true,
       "show": true
     },
@@ -150,6 +160,11 @@
       "hostDocs": true
     },
     {
+      "version": "8.0.3-v13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "8.0.3-v12",
       "hostDocs": true,
       "show": true
@@ -235,6 +250,11 @@
     {
       "version": "8.0.3-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "5.7.25-v13",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "5.7.25-v12",
@@ -324,5 +344,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "8.0.21-v6"
+  "latestVersion": "8.0.21-v7"
 }

--- a/data/products/stash-nats.json
+++ b/data/products/stash-nats.json
@@ -26,7 +26,12 @@
       "version": "master",
       "hostDocs": false,
       "show": true
+    },
+    {
+      "version": "2.6.1",
+      "hostDocs": true,
+      "show": true
     }
   ],
-  "latestVersion": "master"
+  "latestVersion": "2.6.1"
 }

--- a/data/products/stash-percona-xtradb.json
+++ b/data/products/stash-percona-xtradb.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "5.7-v8",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "5.7-v7",
       "hostDocs": true,
       "show": true
@@ -53,12 +58,12 @@
       "show": true
     },
     {
-      "version": "5.7-v2",
+      "version": "5.7.0-v2",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "5.7.0-v2",
+      "version": "5.7-v2",
       "hostDocs": true,
       "show": true
     },
@@ -73,12 +78,12 @@
       "show": true
     },
     {
-      "version": "5.7.0",
+      "version": "5.7",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "5.7",
+      "version": "5.7.0",
       "hostDocs": true,
       "show": true
     },
@@ -105,5 +110,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "5.7-v7"
+  "latestVersion": "5.7-v8"
 }

--- a/data/products/stash-postgres.json
+++ b/data/products/stash-postgres.json
@@ -28,6 +28,16 @@
       "show": true
     },
     {
+      "version": "14.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "13.1-v8",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "13.1-v7",
       "hostDocs": true,
       "show": true
@@ -69,6 +79,11 @@
     },
     {
       "version": "13.1.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "12.4-v11",
       "hostDocs": true,
       "show": true
     },
@@ -129,6 +144,11 @@
     },
     {
       "version": "12.4.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "11.9-v11",
       "hostDocs": true,
       "show": true
     },
@@ -257,6 +277,11 @@
       "hostDocs": true
     },
     {
+      "version": "10.14-v11",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "10.14-v10",
       "hostDocs": true,
       "show": true
@@ -282,12 +307,12 @@
       "show": true
     },
     {
-      "version": "10.14.0-v5",
+      "version": "10.14-v5",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "10.14-v5",
+      "version": "10.14.0-v5",
       "hostDocs": true,
       "show": true
     },
@@ -381,6 +406,11 @@
       "hostDocs": true
     },
     {
+      "version": "9.6.19-v11",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "9.6.19-v10",
       "hostDocs": true,
       "show": true
@@ -468,5 +498,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "13.1-v7"
+  "latestVersion": "14.0"
 }

--- a/data/products/stash.json
+++ b/data/products/stash.json
@@ -299,6 +299,72 @@
       "show": true
     },
     {
+      "version": "v2021.10.11",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.16.0",
+        "community": "v0.16.0",
+        "elasticsearch": [
+          "5.6.4-v13",
+          "6.2.4-v13",
+          "6.3.0-v13",
+          "6.4.0-v13",
+          "6.5.3-v13",
+          "6.8.0-v13",
+          "7.2.0-v13",
+          "7.3.2-v13"
+        ],
+        "enterprise": "v0.16.0",
+        "etcd": [
+          "3.5.0"
+        ],
+        "installer": "v2021.10.11",
+        "mariadb": [
+          "10.5.8-v6"
+        ],
+        "mongodb": [
+          "3.4.17-v12",
+          "3.4.22-v12",
+          "3.6.13-v12",
+          "3.6.8-v12",
+          "4.0.11-v12",
+          "4.0.3-v12",
+          "4.0.5-v12",
+          "4.1.13-v12",
+          "4.1.4-v12",
+          "4.1.7-v12",
+          "4.2.3-v12",
+          "4.4.6-v3",
+          "5.0.3"
+        ],
+        "mysql": [
+          "5.7.25-v13",
+          "8.0.14-v13",
+          "8.0.21-v7",
+          "8.0.3-v13"
+        ],
+        "nats": [
+          "2.6.1"
+        ],
+        "percona-xtradb": [
+          "5.7-v8"
+        ],
+        "postgres": [
+          "10.14-v11",
+          "11.9-v11",
+          "12.4-v11",
+          "13.1-v8",
+          "14.0",
+          "9.6.19-v11"
+        ],
+        "redis": [
+          "5.0.13-v1",
+          "6.2.5-v1"
+        ]
+      }
+    },
+    {
       "version": "v2021.08.02",
       "hostDocs": true,
       "show": true,
@@ -1392,7 +1458,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2021.08.02",
+  "latestVersion": "v2021.10.11",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/stashed/stash",


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.10.11
Release-tracker: https://github.com/stashed/CHANGELOG/pull/41