### PR TITLE
Update for release KubeVault@v2021.10.11

### DIFF
--- a/data/products/kubevault.json
+++ b/data/products/kubevault.json
@@ -133,6 +133,17 @@
       "show": true
     },
     {
+      "version": "v2021.10.11",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.5.1",
+        "installer": "v2021.10.11",
+        "operator": "v0.5.1",
+        "unsealer": "v0.5.1"
+      }
+    },
+    {
       "version": "v2021.09.27",
       "hostDocs": true,
       "show": true,
@@ -155,7 +166,7 @@
       }
     }
   ],
-  "latestVersion": "v2021.09.27",
+  "latestVersion": "v2021.10.11",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubevault",


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2021.10.11
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/22