### PR TITLE
Update for release Stash@v2021.11.24

### DIFF
--- a/data/products/stash-cli.json
+++ b/data/products/stash-cli.json
@@ -23,6 +23,73 @@
       "show": true
     },
     {
+      "version": "v0.17.0",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "stash": "v2021.11.24",
+        "stash-community": "v0.17.0",
+        "stash-elasticsearch": [
+          "5.6.4-v14",
+          "6.2.4-v14",
+          "6.3.0-v14",
+          "6.4.0-v14",
+          "6.5.3-v14",
+          "6.8.0-v14",
+          "7.14.0",
+          "7.2.0-v14",
+          "7.3.2-v14"
+        ],
+        "stash-enterprise": "v0.17.0",
+        "stash-etcd": [
+          "3.5.0-v1"
+        ],
+        "stash-installer": "v2021.11.24",
+        "stash-mariadb": [
+          "10.5.8-v7"
+        ],
+        "stash-mongodb": [
+          "3.4.17-v13",
+          "3.4.22-v13",
+          "3.6.13-v13",
+          "3.6.8-v13",
+          "4.0.11-v13",
+          "4.0.3-v13",
+          "4.0.5-v13",
+          "4.1.13-v13",
+          "4.1.4-v13",
+          "4.1.7-v13",
+          "4.2.3-v13",
+          "4.4.6-v4",
+          "5.0.3-v1"
+        ],
+        "stash-mysql": [
+          "5.7.25-v14",
+          "8.0.14-v14",
+          "8.0.21-v8",
+          "8.0.3-v14"
+        ],
+        "stash-nats": [
+          "2.6.1-v1"
+        ],
+        "stash-percona-xtradb": [
+          "5.7-v9"
+        ],
+        "stash-postgres": [
+          "10.14-v12",
+          "11.9-v12",
+          "12.4-v12",
+          "13.1-v9",
+          "14.0-v1",
+          "9.6.19-v12"
+        ],
+        "stash-redis": [
+          "5.0.13-v2",
+          "6.2.5-v2"
+        ]
+      }
+    },
+    {
       "version": "v0.16.0",
       "hostDocs": true,
       "show": true,
@@ -986,5 +1053,5 @@
       "show": true
     }
   ],
-  "latestVersion": "v0.16.0"
+  "latestVersion": "v0.17.0"
 }

--- a/data/products/stash-elasticsearch.json
+++ b/data/products/stash-elasticsearch.json
@@ -28,6 +28,16 @@
       "show": true
     },
     {
+      "version": "7.14.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "7.3.2-v14",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "7.3.2-v13",
       "hostDocs": true,
       "show": true
@@ -118,6 +128,11 @@
     {
       "version": "7.3.2-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "7.2.0-v14",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "7.2.0-v13",
@@ -212,6 +227,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.8.0-v14",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.8.0-v13",
       "hostDocs": true,
       "show": true
@@ -302,6 +322,11 @@
     {
       "version": "6.8.0-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "6.5.3-v14",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "6.5.3-v13",
@@ -396,6 +421,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.4.0-v14",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.4.0-v13",
       "hostDocs": true,
       "show": true
@@ -486,6 +516,11 @@
     {
       "version": "6.4.0-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "6.3.0-v14",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "6.3.0-v13",
@@ -580,6 +615,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.2.4-v14",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.2.4-v13",
       "hostDocs": true,
       "show": true
@@ -670,6 +710,11 @@
     {
       "version": "6.2.4-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "5.6.4-v14",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "5.6.4-v13",
@@ -764,5 +809,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "7.3.2-v13"
+  "latestVersion": "7.14.0"
 }

--- a/data/products/stash-etcd.json
+++ b/data/products/stash-etcd.json
@@ -28,10 +28,15 @@
       "show": true
     },
     {
+      "version": "3.5.0-v1",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.5.0",
       "hostDocs": true,
       "show": true
     }
   ],
-  "latestVersion": "3.5.0"
+  "latestVersion": "3.5.0-v1"
 }

--- a/data/products/stash-mariadb.json
+++ b/data/products/stash-mariadb.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "10.5.8-v7",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "10.5.8-v6",
       "hostDocs": true,
       "show": true
@@ -63,5 +68,5 @@
       "show": true
     }
   ],
-  "latestVersion": "10.5.8-v6"
+  "latestVersion": "10.5.8-v7"
 }

--- a/data/products/stash-mongodb.json
+++ b/data/products/stash-mongodb.json
@@ -28,7 +28,17 @@
       "show": true
     },
     {
+      "version": "5.0.3-v1",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "5.0.3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.4.6-v4",
       "hostDocs": true,
       "show": true
     },
@@ -49,6 +59,11 @@
     },
     {
       "version": "4.4.6",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.2.3-v13",
       "hostDocs": true,
       "show": true
     },
@@ -140,6 +155,11 @@
       "hostDocs": true
     },
     {
+      "version": "4.1.13-v13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.1.13-v12",
       "hostDocs": true,
       "show": true
@@ -201,6 +221,11 @@
     },
     {
       "version": "4.1.13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.1.7-v13",
       "hostDocs": true,
       "show": true
     },
@@ -290,6 +315,11 @@
     {
       "version": "4.1.7-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "4.1.4-v13",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "4.1.4-v12",
@@ -401,6 +431,11 @@
       "hostDocs": true
     },
     {
+      "version": "4.0.11-v13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.0.11-v12",
       "hostDocs": true,
       "show": true
@@ -472,6 +507,11 @@
     },
     {
       "version": "4.0.11-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.0.5-v13",
       "hostDocs": true,
       "show": true
     },
@@ -561,6 +601,11 @@
     {
       "version": "4.0.5-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "4.0.3-v13",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "4.0.3-v12",
@@ -662,6 +707,11 @@
       "hostDocs": true
     },
     {
+      "version": "3.6.13-v13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.6.13-v12",
       "hostDocs": true,
       "show": true
@@ -723,6 +773,11 @@
     },
     {
       "version": "3.6.13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "3.6.8-v13",
       "hostDocs": true,
       "show": true
     },
@@ -836,6 +891,11 @@
       "hostDocs": true
     },
     {
+      "version": "3.4.22-v13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.4.22-v12",
       "hostDocs": true,
       "show": true
@@ -897,6 +957,11 @@
     },
     {
       "version": "3.4.22",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "3.4.17-v13",
       "hostDocs": true,
       "show": true
     },
@@ -1010,5 +1075,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "5.0.3"
+  "latestVersion": "5.0.3-v1"
 }

--- a/data/products/stash-mysql.json
+++ b/data/products/stash-mysql.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "8.0.21-v8",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "8.0.21-v7",
       "hostDocs": true,
       "show": true
@@ -64,6 +69,11 @@
     },
     {
       "version": "8.0.21",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "8.0.14-v14",
       "hostDocs": true,
       "show": true
     },
@@ -160,6 +170,11 @@
       "hostDocs": true
     },
     {
+      "version": "8.0.3-v14",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "8.0.3-v13",
       "hostDocs": true,
       "show": true
@@ -250,6 +265,11 @@
     {
       "version": "8.0.3-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "5.7.25-v14",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "5.7.25-v13",
@@ -344,5 +364,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "8.0.21-v7"
+  "latestVersion": "8.0.21-v8"
 }

--- a/data/products/stash-nats.json
+++ b/data/products/stash-nats.json
@@ -28,10 +28,15 @@
       "show": true
     },
     {
+      "version": "2.6.1-v1",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "2.6.1",
       "hostDocs": true,
       "show": true
     }
   ],
-  "latestVersion": "2.6.1"
+  "latestVersion": "2.6.1-v1"
 }

--- a/data/products/stash-percona-xtradb.json
+++ b/data/products/stash-percona-xtradb.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "5.7-v9",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "5.7-v8",
       "hostDocs": true,
       "show": true
@@ -58,12 +63,12 @@
       "show": true
     },
     {
-      "version": "5.7.0-v2",
+      "version": "5.7-v2",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "5.7-v2",
+      "version": "5.7.0-v2",
       "hostDocs": true,
       "show": true
     },
@@ -78,12 +83,12 @@
       "show": true
     },
     {
-      "version": "5.7",
+      "version": "5.7.0",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "5.7.0",
+      "version": "5.7",
       "hostDocs": true,
       "show": true
     },
@@ -110,5 +115,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "5.7-v8"
+  "latestVersion": "5.7-v9"
 }

--- a/data/products/stash-postgres.json
+++ b/data/products/stash-postgres.json
@@ -28,7 +28,17 @@
       "show": true
     },
     {
+      "version": "14.0-v1",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "14.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "13.1-v9",
       "hostDocs": true,
       "show": true
     },
@@ -63,12 +73,12 @@
       "show": true
     },
     {
-      "version": "13.1-v2",
+      "version": "13.1.0-v2",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "13.1.0-v2",
+      "version": "13.1-v2",
       "hostDocs": true,
       "show": true
     },
@@ -79,6 +89,11 @@
     },
     {
       "version": "13.1.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "12.4-v12",
       "hostDocs": true,
       "show": true
     },
@@ -148,6 +163,11 @@
       "show": true
     },
     {
+      "version": "11.9-v12",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "11.9-v11",
       "hostDocs": true,
       "show": true
@@ -178,12 +198,12 @@
       "show": true
     },
     {
-      "version": "11.9.0-v5",
+      "version": "11.9-v5",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "11.9-v5",
+      "version": "11.9.0-v5",
       "hostDocs": true,
       "show": true
     },
@@ -277,6 +297,11 @@
       "hostDocs": true
     },
     {
+      "version": "10.14-v12",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "10.14-v11",
       "hostDocs": true,
       "show": true
@@ -307,12 +332,12 @@
       "show": true
     },
     {
-      "version": "10.14-v5",
+      "version": "10.14.0-v5",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "10.14.0-v5",
+      "version": "10.14-v5",
       "hostDocs": true,
       "show": true
     },
@@ -404,6 +429,11 @@
     {
       "version": "10.2-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "9.6.19-v12",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "9.6.19-v11",
@@ -498,5 +528,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "14.0"
+  "latestVersion": "14.0-v1"
 }

--- a/data/products/stash.json
+++ b/data/products/stash.json
@@ -299,6 +299,73 @@
       "show": true
     },
     {
+      "version": "v2021.11.24",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.17.0",
+        "community": "v0.17.0",
+        "elasticsearch": [
+          "5.6.4-v14",
+          "6.2.4-v14",
+          "6.3.0-v14",
+          "6.4.0-v14",
+          "6.5.3-v14",
+          "6.8.0-v14",
+          "7.14.0",
+          "7.2.0-v14",
+          "7.3.2-v14"
+        ],
+        "enterprise": "v0.17.0",
+        "etcd": [
+          "3.5.0-v1"
+        ],
+        "installer": "v2021.11.24",
+        "mariadb": [
+          "10.5.8-v7"
+        ],
+        "mongodb": [
+          "3.4.17-v13",
+          "3.4.22-v13",
+          "3.6.13-v13",
+          "3.6.8-v13",
+          "4.0.11-v13",
+          "4.0.3-v13",
+          "4.0.5-v13",
+          "4.1.13-v13",
+          "4.1.4-v13",
+          "4.1.7-v13",
+          "4.2.3-v13",
+          "4.4.6-v4",
+          "5.0.3-v1"
+        ],
+        "mysql": [
+          "5.7.25-v14",
+          "8.0.14-v14",
+          "8.0.21-v8",
+          "8.0.3-v14"
+        ],
+        "nats": [
+          "2.6.1-v1"
+        ],
+        "percona-xtradb": [
+          "5.7-v9"
+        ],
+        "postgres": [
+          "10.14-v12",
+          "11.9-v12",
+          "12.4-v12",
+          "13.1-v9",
+          "14.0-v1",
+          "9.6.19-v12"
+        ],
+        "redis": [
+          "5.0.13-v2",
+          "6.2.5-v2"
+        ]
+      }
+    },
+    {
       "version": "v2021.10.11",
       "hostDocs": true,
       "show": true,
@@ -1458,7 +1525,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2021.10.11",
+  "latestVersion": "v2021.11.24",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/stashed/stash",


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.11.24
Release-tracker: https://github.com/stashed/CHANGELOG/pull/43