### PR TITLE
Update for release KubeVault@v2022.01.11

### DIFF
--- a/data/products/kubevault.json
+++ b/data/products/kubevault.json
@@ -133,6 +133,17 @@
       "show": true
     },
     {
+      "version": "v2022.01.11",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.6.0",
+        "installer": "v2022.01.11",
+        "operator": "v0.6.0",
+        "unsealer": "v0.6.0"
+      }
+    },
+    {
       "version": "v2021.10.11",
       "hostDocs": true,
       "show": true,
@@ -166,7 +177,7 @@
       }
     }
   ],
-  "latestVersion": "v2021.10.11",
+  "latestVersion": "v2022.01.11",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubevault",


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2022.01.11
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/24