### PR TITLE
Update for release Stash@v2022.02.22

### DIFF
--- a/data/products/stash-cli.json
+++ b/data/products/stash-cli.json
@@ -23,6 +23,74 @@
       "show": true
     },
     {
+      "version": "v0.18.0",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "stash": "v2022.02.22",
+        "stash-community": "v0.18.0",
+        "stash-elasticsearch": [
+          "5.6.4-v15",
+          "6.2.4-v15",
+          "6.3.0-v15",
+          "6.4.0-v15",
+          "6.5.3-v15",
+          "6.8.0-v15",
+          "7.14.0-v1",
+          "7.2.0-v15",
+          "7.3.2-v15"
+        ],
+        "stash-enterprise": "v0.18.0",
+        "stash-etcd": [
+          "3.5.0-v2"
+        ],
+        "stash-installer": "v2022.02.22",
+        "stash-mariadb": [
+          "10.5.8-v8"
+        ],
+        "stash-mongodb": [
+          "3.4.17-v14",
+          "3.4.22-v14",
+          "3.6.13-v14",
+          "3.6.8-v14",
+          "4.0.11-v14",
+          "4.0.3-v14",
+          "4.0.5-v14",
+          "4.1.13-v14",
+          "4.1.4-v14",
+          "4.1.7-v14",
+          "4.2.3-v14",
+          "4.4.6-v5",
+          "5.0.3-v2"
+        ],
+        "stash-mysql": [
+          "5.7.25-v15",
+          "8.0.14-v15",
+          "8.0.21-v9",
+          "8.0.3-v15"
+        ],
+        "stash-nats": [
+          "2.6.1-v2"
+        ],
+        "stash-percona-xtradb": [
+          "5.7-v10"
+        ],
+        "stash-postgres": [
+          "10.14-v13",
+          "11.9-v13",
+          "12.4-v13",
+          "13.1-v10",
+          "14.0-v2",
+          "9.6.19-v13"
+        ],
+        "stash-redis": [
+          "5.0.13-v3",
+          "6.2.5-v3"
+        ],
+        "stash-ui-server": "v0.1.0"
+      }
+    },
+    {
       "version": "v0.17.0",
       "hostDocs": true,
       "show": true,
@@ -1053,5 +1121,5 @@
       "show": true
     }
   ],
-  "latestVersion": "v0.17.0"
+  "latestVersion": "v0.18.0"
 }

--- a/data/products/stash-elasticsearch.json
+++ b/data/products/stash-elasticsearch.json
@@ -28,7 +28,17 @@
       "show": true
     },
     {
+      "version": "7.14.0-v1",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "7.14.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "7.3.2-v15",
       "hostDocs": true,
       "show": true
     },
@@ -130,6 +140,11 @@
       "hostDocs": true
     },
     {
+      "version": "7.2.0-v15",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "7.2.0-v14",
       "hostDocs": true,
       "show": true
@@ -225,6 +240,11 @@
     {
       "version": "7.2.0-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "6.8.0-v15",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "6.8.0-v14",
@@ -324,6 +344,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.5.3-v15",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.5.3-v14",
       "hostDocs": true,
       "show": true
@@ -419,6 +444,11 @@
     {
       "version": "6.5.3-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "6.4.0-v15",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "6.4.0-v14",
@@ -518,6 +548,11 @@
       "hostDocs": true
     },
     {
+      "version": "6.3.0-v15",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "6.3.0-v14",
       "hostDocs": true,
       "show": true
@@ -613,6 +648,11 @@
     {
       "version": "6.3.0-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "6.2.4-v15",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "6.2.4-v14",
@@ -712,6 +752,11 @@
       "hostDocs": true
     },
     {
+      "version": "5.6.4-v15",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "5.6.4-v14",
       "hostDocs": true,
       "show": true
@@ -809,5 +854,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "7.14.0"
+  "latestVersion": "7.14.0-v1"
 }

--- a/data/products/stash-etcd.json
+++ b/data/products/stash-etcd.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "3.5.0-v2",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.5.0-v1",
       "hostDocs": true,
       "show": true
@@ -38,5 +43,5 @@
       "show": true
     }
   ],
-  "latestVersion": "3.5.0-v1"
+  "latestVersion": "3.5.0-v2"
 }

--- a/data/products/stash-mariadb.json
+++ b/data/products/stash-mariadb.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "10.5.8-v8",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "10.5.8-v7",
       "hostDocs": true,
       "show": true
@@ -68,5 +73,5 @@
       "show": true
     }
   ],
-  "latestVersion": "10.5.8-v7"
+  "latestVersion": "10.5.8-v8"
 }

--- a/data/products/stash-mongodb.json
+++ b/data/products/stash-mongodb.json
@@ -28,12 +28,22 @@
       "show": true
     },
     {
+      "version": "5.0.3-v2",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "5.0.3-v1",
       "hostDocs": true,
       "show": true
     },
     {
       "version": "5.0.3",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.4.6-v5",
       "hostDocs": true,
       "show": true
     },
@@ -59,6 +69,11 @@
     },
     {
       "version": "4.4.6",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.2.3-v14",
       "hostDocs": true,
       "show": true
     },
@@ -155,6 +170,11 @@
       "hostDocs": true
     },
     {
+      "version": "4.1.13-v14",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.1.13-v13",
       "hostDocs": true,
       "show": true
@@ -221,6 +241,11 @@
     },
     {
       "version": "4.1.13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.1.7-v14",
       "hostDocs": true,
       "show": true
     },
@@ -315,6 +340,11 @@
     {
       "version": "4.1.7-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "4.1.4-v14",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "4.1.4-v13",
@@ -431,6 +461,11 @@
       "hostDocs": true
     },
     {
+      "version": "4.0.11-v14",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "4.0.11-v13",
       "hostDocs": true,
       "show": true
@@ -507,6 +542,11 @@
     },
     {
       "version": "4.0.11-rc.20200826",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "4.0.5-v14",
       "hostDocs": true,
       "show": true
     },
@@ -601,6 +641,11 @@
     {
       "version": "4.0.5-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "4.0.3-v14",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "4.0.3-v13",
@@ -707,6 +752,11 @@
       "hostDocs": true
     },
     {
+      "version": "3.6.13-v14",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.6.13-v13",
       "hostDocs": true,
       "show": true
@@ -773,6 +823,11 @@
     },
     {
       "version": "3.6.13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "3.6.8-v14",
       "hostDocs": true,
       "show": true
     },
@@ -891,6 +946,11 @@
       "hostDocs": true
     },
     {
+      "version": "3.4.22-v14",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "3.4.22-v13",
       "hostDocs": true,
       "show": true
@@ -957,6 +1017,11 @@
     },
     {
       "version": "3.4.22",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "3.4.17-v14",
       "hostDocs": true,
       "show": true
     },
@@ -1075,5 +1140,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "5.0.3-v1"
+  "latestVersion": "5.0.3-v2"
 }

--- a/data/products/stash-mysql.json
+++ b/data/products/stash-mysql.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "8.0.21-v9",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "8.0.21-v8",
       "hostDocs": true,
       "show": true
@@ -69,6 +74,11 @@
     },
     {
       "version": "8.0.21",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "8.0.14-v15",
       "hostDocs": true,
       "show": true
     },
@@ -170,6 +180,11 @@
       "hostDocs": true
     },
     {
+      "version": "8.0.3-v15",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "8.0.3-v14",
       "hostDocs": true,
       "show": true
@@ -265,6 +280,11 @@
     {
       "version": "8.0.3-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "5.7.25-v15",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "5.7.25-v14",
@@ -364,5 +384,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "8.0.21-v8"
+  "latestVersion": "8.0.21-v9"
 }

--- a/data/products/stash-nats.json
+++ b/data/products/stash-nats.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "2.6.1-v2",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "2.6.1-v1",
       "hostDocs": true,
       "show": true
@@ -38,5 +43,5 @@
       "show": true
     }
   ],
-  "latestVersion": "2.6.1-v1"
+  "latestVersion": "2.6.1-v2"
 }

--- a/data/products/stash-percona-xtradb.json
+++ b/data/products/stash-percona-xtradb.json
@@ -28,6 +28,11 @@
       "show": true
     },
     {
+      "version": "5.7-v10",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "5.7-v9",
       "hostDocs": true,
       "show": true
@@ -63,12 +68,12 @@
       "show": true
     },
     {
-      "version": "5.7-v2",
+      "version": "5.7.0-v2",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "5.7.0-v2",
+      "version": "5.7-v2",
       "hostDocs": true,
       "show": true
     },
@@ -83,12 +88,12 @@
       "show": true
     },
     {
-      "version": "5.7.0",
+      "version": "5.7",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "5.7",
+      "version": "5.7.0",
       "hostDocs": true,
       "show": true
     },
@@ -115,5 +120,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "5.7-v9"
+  "latestVersion": "5.7-v10"
 }

--- a/data/products/stash-postgres.json
+++ b/data/products/stash-postgres.json
@@ -28,12 +28,22 @@
       "show": true
     },
     {
+      "version": "14.0-v2",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "14.0-v1",
       "hostDocs": true,
       "show": true
     },
     {
       "version": "14.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "13.1-v10",
       "hostDocs": true,
       "show": true
     },
@@ -73,12 +83,12 @@
       "show": true
     },
     {
-      "version": "13.1.0-v2",
+      "version": "13.1-v2",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "13.1-v2",
+      "version": "13.1.0-v2",
       "hostDocs": true,
       "show": true
     },
@@ -89,6 +99,11 @@
     },
     {
       "version": "13.1.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "12.4-v13",
       "hostDocs": true,
       "show": true
     },
@@ -128,12 +143,12 @@
       "show": true
     },
     {
-      "version": "12.4.0-v5",
+      "version": "12.4-v5",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "12.4-v5",
+      "version": "12.4.0-v5",
       "hostDocs": true,
       "show": true
     },
@@ -159,6 +174,11 @@
     },
     {
       "version": "12.4.0",
+      "hostDocs": true,
+      "show": true
+    },
+    {
+      "version": "11.9-v13",
       "hostDocs": true,
       "show": true
     },
@@ -198,12 +218,12 @@
       "show": true
     },
     {
-      "version": "11.9-v5",
+      "version": "11.9.0-v5",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "11.9.0-v5",
+      "version": "11.9-v5",
       "hostDocs": true,
       "show": true
     },
@@ -297,6 +317,11 @@
       "hostDocs": true
     },
     {
+      "version": "10.14-v13",
+      "hostDocs": true,
+      "show": true
+    },
+    {
       "version": "10.14-v12",
       "hostDocs": true,
       "show": true
@@ -332,12 +357,12 @@
       "show": true
     },
     {
-      "version": "10.14.0-v5",
+      "version": "10.14-v5",
       "hostDocs": true,
       "show": true
     },
     {
-      "version": "10.14-v5",
+      "version": "10.14.0-v5",
       "hostDocs": true,
       "show": true
     },
@@ -429,6 +454,11 @@
     {
       "version": "10.2-beta.20200708",
       "hostDocs": true
+    },
+    {
+      "version": "9.6.19-v13",
+      "hostDocs": true,
+      "show": true
     },
     {
       "version": "9.6.19-v12",
@@ -528,5 +558,5 @@
       "hostDocs": true
     }
   ],
-  "latestVersion": "14.0-v1"
+  "latestVersion": "14.0-v2"
 }

--- a/data/products/stash.json
+++ b/data/products/stash.json
@@ -299,6 +299,74 @@
       "show": true
     },
     {
+      "version": "v2022.02.22",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.18.0",
+        "community": "v0.18.0",
+        "elasticsearch": [
+          "5.6.4-v15",
+          "6.2.4-v15",
+          "6.3.0-v15",
+          "6.4.0-v15",
+          "6.5.3-v15",
+          "6.8.0-v15",
+          "7.14.0-v1",
+          "7.2.0-v15",
+          "7.3.2-v15"
+        ],
+        "enterprise": "v0.18.0",
+        "etcd": [
+          "3.5.0-v2"
+        ],
+        "installer": "v2022.02.22",
+        "mariadb": [
+          "10.5.8-v8"
+        ],
+        "mongodb": [
+          "3.4.17-v14",
+          "3.4.22-v14",
+          "3.6.13-v14",
+          "3.6.8-v14",
+          "4.0.11-v14",
+          "4.0.3-v14",
+          "4.0.5-v14",
+          "4.1.13-v14",
+          "4.1.4-v14",
+          "4.1.7-v14",
+          "4.2.3-v14",
+          "4.4.6-v5",
+          "5.0.3-v2"
+        ],
+        "mysql": [
+          "5.7.25-v15",
+          "8.0.14-v15",
+          "8.0.21-v9",
+          "8.0.3-v15"
+        ],
+        "nats": [
+          "2.6.1-v2"
+        ],
+        "percona-xtradb": [
+          "5.7-v10"
+        ],
+        "postgres": [
+          "10.14-v13",
+          "11.9-v13",
+          "12.4-v13",
+          "13.1-v10",
+          "14.0-v2",
+          "9.6.19-v13"
+        ],
+        "redis": [
+          "5.0.13-v3",
+          "6.2.5-v3"
+        ],
+        "ui-server": "v0.1.0"
+      }
+    },
+    {
       "version": "v2021.11.24",
       "hostDocs": true,
       "show": true,
@@ -1525,7 +1593,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2021.11.24",
+  "latestVersion": "v2022.02.22",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/stashed/stash",


### PR DESCRIPTION
ProductLine: Stash
Release: v2022.02.22
Release-tracker: https://github.com/stashed/CHANGELOG/pull/44