### PR TITLE
Update for release KubeDB@v2022.02.22

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -163,6 +163,21 @@
       "show": true
     },
     {
+      "version": "v2022.02.22",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.10.0",
+        "cli": "v0.25.0",
+        "community": "v0.25.0",
+        "dashboard": "v0.1.0",
+        "enterprise": "v0.12.0",
+        "installer": "v2022.02.22",
+        "schema-manager": "v0.1.0",
+        "ui-server": "v0.1.0",
+        "webhook-server": "v0.1.0"
+      }
+    },
+    {
       "version": "v2021.12.21",
       "hostDocs": true,
       "show": true,
@@ -189,7 +204,6 @@
     {
       "version": "v2021.11.18",
       "hostDocs": true,
-      "show": false,
       "info": {
         "autoscaler": "v0.8.0",
         "cli": "v0.23.0",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2022.02.22
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/48