### PR TITLE
Update for release KubeDB@v2022.08.02-rc.0

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2022.08.02-rc.0",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.13.0-rc.0",
+        "cli": "v0.28.0-rc.0",
+        "dashboard": "v0.4.0-rc.0",
+        "installer": "v2022.08.02-rc.0",
+        "ops-manager": "v0.15.0-rc.0",
+        "provisioner": "v0.28.0-rc.0",
+        "schema-manager": "v0.4.0-rc.0",
+        "ui-server": "v0.4.0-rc.0",
+        "webhook-server": "v0.4.0-rc.0"
+      }
+    },
+    {
       "version": "v2022.05.24",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2022.08.02-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/52