### PR TITLE
Update for release KubeDB@v2022.08.04-rc.1

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2022.08.04-rc.1",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.13.0-rc.1",
+        "cli": "v0.28.0-rc.1",
+        "dashboard": "v0.4.0-rc.1",
+        "installer": "v2022.08.04-rc.1",
+        "ops-manager": "v0.15.0-rc.1",
+        "provisioner": "v0.28.0-rc.1",
+        "schema-manager": "v0.4.0-rc.1",
+        "ui-server": "v0.4.0-rc.1",
+        "webhook-server": "v0.4.0-rc.1"
+      }
+    },
+    {
       "version": "v2022.08.02-rc.0",
       "hostDocs": true,
       "show": true,
@@ -570,7 +585,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2022.05.24",
+  "latestVersion": "v2022.08.02-rc.0",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubedb",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2022.08.04-rc.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/53