### PR TITLE
Update for release KubeVault@v2022.09.22

### DIFF
--- a/data/products/kubevault.json
+++ b/data/products/kubevault.json
@@ -209,6 +209,17 @@
       "show": true
     },
     {
+      "version": "v2022.09.22",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.10.0",
+        "installer": "v2022.09.22",
+        "operator": "v0.10.0",
+        "unsealer": "v0.10.0"
+      }
+    },
+    {
       "version": "v2022.09.09",
       "hostDocs": true,
       "show": true,
@@ -297,7 +308,7 @@
       }
     }
   ],
-  "latestVersion": "v2022.09.09",
+  "latestVersion": "v2022.09.22",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubevault",


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2022.09.22
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/31