### PR TITLE
Update for release KubeDB@v2022.10.12-rc.0

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2022.10.12-rc.0",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.14.0-rc.0",
+        "cli": "v0.29.0-rc.0",
+        "dashboard": "v0.5.0-rc.0",
+        "installer": "v2022.10.12-rc.0",
+        "ops-manager": "v0.16.0-rc.0",
+        "provisioner": "v0.29.0-rc.0",
+        "schema-manager": "v0.5.0-rc.0",
+        "ui-server": "v0.5.0-rc.0",
+        "webhook-server": "v0.5.0-rc.0"
+      }
+    },
+    {
       "version": "v2022.08.08",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2022.10.12-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/57