### PR TITLE
Update for release KubeDB@v2022.10.18

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2022.10.18",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.14.0",
+        "cli": "v0.29.0",
+        "dashboard": "v0.5.0",
+        "installer": "v2022.10.18",
+        "ops-manager": "v0.16.0",
+        "provisioner": "v0.29.0",
+        "schema-manager": "v0.5.0",
+        "ui-server": "v0.5.0",
+        "webhook-server": "v0.5.0"
+      }
+    },
+    {
       "version": "v2022.10.12-rc.0",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2022.10.18
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/58