### PR TITLE
Update for release KubeVault@v2022.12.09

### DIFF
--- a/data/products/kubevault.json
+++ b/data/products/kubevault.json
@@ -209,6 +209,17 @@
       "show": true
     },
     {
+      "version": "v2022.12.09",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.12.0",
+        "installer": "v2022.12.09",
+        "operator": "v0.12.0",
+        "unsealer": "v0.12.0"
+      }
+    },
+    {
       "version": "v2022.11.30",
       "hostDocs": true,
       "show": true,
@@ -319,7 +330,7 @@
       }
     }
   ],
-  "latestVersion": "v2022.11.30",
+  "latestVersion": "v2022.12.09",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubevault",


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2022.12.09
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/35