### PR TITLE
Update for release KubeVault@v2022.12.28

### DIFF
--- a/data/products/kubevault.json
+++ b/data/products/kubevault.json
@@ -223,6 +223,17 @@
       "show": true
     },
     {
+      "version": "v2022.12.28",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.13.0",
+        "installer": "v2022.12.28",
+        "operator": "v0.13.0",
+        "unsealer": "v0.13.0"
+      }
+    },
+    {
       "version": "v2022.12.09",
       "hostDocs": true,
       "show": true,
@@ -344,7 +355,7 @@
       }
     }
   ],
-  "latestVersion": "v2022.12.09",
+  "latestVersion": "v2022.12.28",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubevault",


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2022.12.28
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/38