### PR TITLE
Update for release KubeDB@v2022.12.28

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2022.12.28",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.15.0",
+        "cli": "v0.30.0",
+        "dashboard": "v0.6.0",
+        "installer": "v2022.12.28",
+        "ops-manager": "v0.17.0",
+        "provisioner": "v0.30.0",
+        "schema-manager": "v0.6.0",
+        "ui-server": "v0.6.0",
+        "webhook-server": "v0.6.0"
+      }
+    },
+    {
       "version": "v2022.12.24-rc.1",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2022.12.28
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/62