### PR TITLE
Update for release KubeDB@v2023.01.17

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2023.01.17",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.15.1",
+        "cli": "v0.30.1",
+        "dashboard": "v0.6.1",
+        "installer": "v2023.01.17",
+        "ops-manager": "v0.17.1",
+        "provisioner": "v0.30.1",
+        "schema-manager": "v0.6.1",
+        "ui-server": "v0.6.1",
+        "webhook-server": "v0.6.1"
+      }
+    },
+    {
       "version": "v2022.12.28",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.01.17
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/63