### PR TITLE
Update for release KubeDB@v2023.01.31

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2023.01.31",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.16.0",
+        "cli": "v0.31.0",
+        "dashboard": "v0.7.0",
+        "installer": "v2023.01.31",
+        "ops-manager": "v0.18.0",
+        "provisioner": "v0.31.0",
+        "schema-manager": "v0.7.0",
+        "ui-server": "v0.7.0",
+        "webhook-server": "v0.7.0"
+      }
+    },
+    {
       "version": "v2023.01.17",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.01.31
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/64