### PR TITLE
Update for release KubeDB@v2023.02.28

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2023.02.28",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.17.0",
+        "cli": "v0.32.0",
+        "dashboard": "v0.8.0",
+        "installer": "v2023.02.28",
+        "ops-manager": "v0.19.0",
+        "provisioner": "v0.32.0",
+        "schema-manager": "v0.8.0",
+        "ui-server": "v0.8.0",
+        "webhook-server": "v0.8.0"
+      }
+    },
+    {
       "version": "v2023.01.31",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.02.28
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/65