### PR TITLE
Update for release KubeDB@v2023.04.10

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2023.04.10",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.18.0",
+        "cli": "v0.33.0",
+        "dashboard": "v0.9.0",
+        "installer": "v2023.04.10",
+        "ops-manager": "v0.20.0",
+        "provisioner": "v0.33.0",
+        "schema-manager": "v0.9.0",
+        "ui-server": "v0.9.0",
+        "webhook-server": "v0.9.0"
+      }
+    },
+    {
       "version": "v2023.02.28",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.04.10
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/69