### PR TITLE
Update for release KubeVault@v2023.05.05

### DIFF
--- a/data/products/kubevault.json
+++ b/data/products/kubevault.json
@@ -223,6 +223,17 @@
       "show": true
     },
     {
+      "version": "v2023.05.05",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.15.0",
+        "installer": "v2023.05.05",
+        "operator": "v0.15.0",
+        "unsealer": "v0.15.0"
+      }
+    },
+    {
       "version": "v2023.03.03",
       "hostDocs": true,
       "show": true,
@@ -366,7 +377,7 @@
       }
     }
   ],
-  "latestVersion": "v2023.03.03",
+  "latestVersion": "v2023.05.05",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubevault",


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2023.05.05
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/42