### PR TITLE
Update for release KubeDB@v2023.08.18

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2023.08.18",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.20.0",
+        "cli": "v0.35.0",
+        "dashboard": "v0.11.0",
+        "installer": "v2023.08.18",
+        "ops-manager": "v0.22.0",
+        "provisioner": "v0.35.0",
+        "schema-manager": "v0.11.0",
+        "ui-server": "v0.11.0",
+        "webhook-server": "v0.11.0"
+      }
+    },
+    {
       "version": "v2023.06.19",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.08.18
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/72