### PR TITLE
Update for release KubeDB@v2023.10.9

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2023.10.9",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.21.0",
+        "cli": "v0.36.0",
+        "dashboard": "v0.12.0",
+        "installer": "v2023.10.9",
+        "ops-manager": "v0.23.0",
+        "provisioner": "v0.36.0",
+        "schema-manager": "v0.12.0",
+        "ui-server": "v0.12.0",
+        "webhook-server": "v0.12.0"
+      }
+    },
+    {
       "version": "v2023.08.18",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.10.9
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/73