### PR TITLE
Update for release KubeDB@v2023.12.11

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2023.12.11",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.23.0",
+        "cli": "v0.38.0",
+        "dashboard": "v0.14.0",
+        "installer": "v2023.12.11",
+        "ops-manager": "v0.25.0",
+        "provisioner": "v0.38.0",
+        "schema-manager": "v0.14.0",
+        "ui-server": "v0.14.0",
+        "webhook-server": "v0.14.0"
+      }
+    },
+    {
       "version": "v2023.12.1-rc.1",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.12.11
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/77