### PR TITLE
Update for release KubeDB@v2023.12.21

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2023.12.21",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.24.0",
+        "cli": "v0.39.0",
+        "dashboard": "v0.15.0",
+        "installer": "v2023.12.21",
+        "ops-manager": "v0.26.0",
+        "provisioner": "v0.39.0",
+        "schema-manager": "v0.15.0",
+        "ui-server": "v0.15.0",
+        "webhook-server": "v0.15.0"
+      }
+    },
+    {
       "version": "v2023.12.11",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.12.21
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/78