### PR TITLE
Update for release KubeDB@v2023.12.28

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2023.12.28",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.25.0",
+        "cli": "v0.40.0",
+        "dashboard": "v0.16.0",
+        "installer": "v2023.12.28",
+        "ops-manager": "v0.27.0",
+        "provisioner": "v0.40.0",
+        "schema-manager": "v0.16.0",
+        "ui-server": "v0.16.0",
+        "webhook-server": "v0.16.0"
+      }
+    },
+    {
       "version": "v2023.12.21",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.12.28
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/79