### PR TITLE
Update for release KubeDB@v2024.1.7-beta.0

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2024.1.7-beta.0",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.26.0-beta.0",
+        "cli": "v0.41.0-beta.0",
+        "dashboard": "v0.17.0-beta.0",
+        "installer": "v2024.1.7-beta.0",
+        "ops-manager": "v0.28.0-beta.0",
+        "provisioner": "v0.41.0-beta.0",
+        "schema-manager": "v0.17.0-beta.0",
+        "ui-server": "v0.17.0-beta.0",
+        "webhook-server": "v0.17.0-beta.0"
+      }
+    },
+    {
       "version": "v2023.12.28",
       "hostDocs": true,
       "show": true,
@@ -175,7 +190,6 @@
     {
       "version": "v2023.12.21",
       "hostDocs": true,
-      "show": false,
       "info": {
         "autoscaler": "v0.24.0",
         "cli": "v0.39.0",
@@ -858,10 +872,6 @@
       "hostDocs": true
     },
     {
-      "version": "0.9.0",
-      "hostDocs": true
-    },
-    {
       "version": "0.9.0-rc.2",
       "hostDocs": true
     },
@@ -874,7 +884,7 @@
       "hostDocs": true
     },
     {
-      "version": "0.8.0",
+      "version": "0.9.0",
       "hostDocs": true
     },
     {
@@ -887,6 +897,10 @@
     },
     {
       "version": "0.8.0-beta.0",
+      "hostDocs": true
+    },
+    {
+      "version": "0.8.0",
       "hostDocs": true
     },
     {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.1.7-beta.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/80