### PR TITLE
Update for release KubeDB@v2024.1.19-beta.1

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2024.1.19-beta.1",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.26.0-beta.1",
+        "cli": "v0.41.0-beta.1",
+        "dashboard": "v0.17.0-beta.1",
+        "installer": "v2024.1.19-beta.1",
+        "ops-manager": "v0.28.0-beta.1",
+        "provisioner": "v0.41.0-beta.1",
+        "schema-manager": "v0.17.0-beta.1",
+        "ui-server": "v0.17.0-beta.1",
+        "webhook-server": "v0.17.0-beta.1"
+      }
+    },
+    {
       "version": "v2024.1.7-beta.0",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.1.19-beta.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/81