### PR TITLE
Update for release KubeVault@v2024.1.26-rc.0

### DIFF
--- a/data/products/kubevault.json
+++ b/data/products/kubevault.json
@@ -223,6 +223,17 @@
       "show": true
     },
     {
+      "version": "v2024.1.26-rc.0",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.17.0-rc.0",
+        "installer": "v2024.1.26-rc.0",
+        "operator": "v0.17.0-rc.0",
+        "unsealer": "v0.17.0-rc.0"
+      }
+    },
+    {
       "version": "v2023.9.7",
       "hostDocs": true,
       "show": true,
@@ -388,7 +399,7 @@
       }
     }
   ],
-  "latestVersion": "v2023.9.7",
+  "latestVersion": "v2024.1.26-rc.0",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubevault",


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2024.1.26-rc.0
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/46