### PR TITLE
Update for release KubeDB@v2024.1.28-rc.1

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2024.1.28-rc.1",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.26.0-rc.1",
+        "cli": "v0.41.0-rc.1",
+        "dashboard": "v0.17.0-rc.1",
+        "installer": "v2024.1.28-rc.1",
+        "ops-manager": "v0.28.0-rc.1",
+        "provisioner": "v0.41.0-rc.1",
+        "schema-manager": "v0.17.0-rc.1",
+        "ui-server": "v0.17.0-rc.1",
+        "webhook-server": "v0.17.0-rc.1"
+      }
+    },
+    {
       "version": "v2024.1.26-rc.0",
       "hostDocs": true,
       "show": true,
@@ -943,7 +958,7 @@
       "hostDocs": false
     }
   ],
-  "latestVersion": "v2023.12.28",
+  "latestVersion": "v2024.1.26-rc.0",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubedb",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.1.28-rc.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/83