### PR TITLE
Update for release KubeDB@v2024.2.14

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2024.2.14",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.27.0",
+        "cli": "v0.42.0",
+        "dashboard": "v0.18.0",
+        "installer": "v2024.2.14",
+        "ops-manager": "v0.29.0",
+        "provisioner": "v0.42.0",
+        "schema-manager": "v0.18.0",
+        "ui-server": "v0.18.0",
+        "webhook-server": "v0.18.0"
+      }
+    },
+    {
       "version": "v2024.1.31",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.2.14
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/85