### PR TITLE
Update for release KubeDB@v2024.3.16

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2024.3.16",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.29.0",
+        "cli": "v0.44.0",
+        "dashboard": "v0.20.0",
+        "installer": "v2024.3.16",
+        "ops-manager": "v0.31.0",
+        "provisioner": "v0.44.0",
+        "schema-manager": "v0.20.0",
+        "ui-server": "v0.20.0",
+        "webhook-server": "v0.20.0"
+      }
+    },
+    {
       "version": "v2024.3.9-rc.0",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.3.16
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/87