### PR TITLE
Update for release KubeDB@v2024.4.27

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2024.4.27",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.30.0",
+        "cli": "v0.45.0",
+        "dashboard": "v0.21.0",
+        "installer": "v2024.4.27",
+        "ops-manager": "v0.32.0",
+        "provisioner": "v0.45.0",
+        "schema-manager": "v0.21.0",
+        "ui-server": "v0.21.0",
+        "webhook-server": "v0.21.0"
+      }
+    },
+    {
       "version": "v2024.3.16",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.4.27
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/89