### PR TITLE
Update for release KubeDB@v2024.6.4

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2024.6.4",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.31.0",
+        "cli": "v0.46.0",
+        "dashboard": "v0.22.0",
+        "installer": "v2024.6.4",
+        "ops-manager": "v0.33.0",
+        "provisioner": "v0.46.0",
+        "schema-manager": "v0.22.0",
+        "ui-server": "v0.22.0",
+        "webhook-server": "v0.22.0"
+      }
+    },
+    {
       "version": "v2024.4.27",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.6.4
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/90