### PR TITLE
Update for release KubeDB@v2024.7.3-rc.0

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,19 @@
       "show": true
     },
     {
+      "version": "v2024.7.3-rc.0",
+      "hostDocs": true,
+      "info": {
+        "cli": "v0.47.0-rc.0",
+        "dashboard": "v0.23.0-rc.0",
+        "installer": "v2024.7.3-rc.0",
+        "provisioner": "v0.47.0-rc.0",
+        "schema-manager": "v0.23.0-rc.0",
+        "ui-server": "v0.23.0-rc.0",
+        "webhook-server": "v0.23.0-rc.0"
+      }
+    },
+    {
       "version": "v2024.6.4",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.7.3-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/91