### PR TITLE
Update for release KubeDB@v2024.8.2-rc.2

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2024.8.2-rc.2",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.32.0-rc.2",
+        "cli": "v0.47.0-rc.2",
+        "dashboard": "v0.23.0-rc.2",
+        "installer": "v2024.8.2-rc.2",
+        "ops-manager": "v0.34.0-rc.2",
+        "provisioner": "v0.47.0-rc.2",
+        "schema-manager": "v0.23.0-rc.2",
+        "ui-server": "v0.23.0-rc.2",
+        "webhook-server": "v0.23.0-rc.2"
+      }
+    },
+    {
       "version": "v2024.7.11-rc.1",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.8.2-rc.2
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/93