### PR TITLE
Update for release KubeDB@v2024.8.14-rc.3

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2024.8.14-rc.3",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.32.0-rc.3",
+        "cli": "v0.47.0-rc.3",
+        "dashboard": "v0.23.0-rc.3",
+        "installer": "v2024.8.14-rc.3",
+        "ops-manager": "v0.34.0-rc.3",
+        "provisioner": "v0.47.0-rc.3",
+        "schema-manager": "v0.23.0-rc.3",
+        "ui-server": "v0.23.0-rc.3",
+        "webhook-server": "v0.23.0-rc.3"
+      }
+    },
+    {
       "version": "v2024.8.2-rc.2",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.8.14-rc.3
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/96