### PR TITLE
Update for release KubeDB@v2024.8.21

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2024.8.21",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.32.0",
+        "cli": "v0.47.0",
+        "dashboard": "v0.23.0",
+        "installer": "v2024.8.21",
+        "ops-manager": "v0.34.0",
+        "provisioner": "v0.47.0",
+        "schema-manager": "v0.23.0",
+        "ui-server": "v0.23.0",
+        "webhook-server": "v0.23.0"
+      }
+    },
+    {
       "version": "v2024.8.14-rc.3",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.8.21
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/98