### PR TITLE
Update for release KubeDB@v2024.9.30

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2024.9.30",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.33.0",
+        "cli": "v0.48.0",
+        "dashboard": "v0.24.0",
+        "installer": "v2024.9.30",
+        "ops-manager": "v0.35.0",
+        "provisioner": "v0.48.0",
+        "schema-manager": "v0.24.0",
+        "ui-server": "v0.24.0",
+        "webhook-server": "v0.24.0"
+      }
+    },
+    {
       "version": "v2024.8.21",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.9.30
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/99