### PR TITLE
Update for release KubeDB@v2024.11.18

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2024.11.18",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.34.0",
+        "cli": "v0.49.0",
+        "dashboard": "v0.25.0",
+        "installer": "v2024.11.18",
+        "ops-manager": "v0.36.0",
+        "provisioner": "v0.49.0",
+        "schema-manager": "v0.25.0",
+        "ui-server": "v0.25.0",
+        "webhook-server": "v0.25.0"
+      }
+    },
+    {
       "version": "v2024.11.8-rc.0",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.11.18
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/101