### PR TITLE
Update for release KubeVault@v2025.2.6-rc.0

### DIFF
--- a/data/products/kubevault.json
+++ b/data/products/kubevault.json
@@ -223,6 +223,17 @@
       "show": true
     },
     {
+      "version": "v2025.2.6-rc.0",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.20.0-rc.0",
+        "installer": "v2025.2.6-rc.0",
+        "operator": "v0.20.0-rc.0",
+        "unsealer": "v0.20.0-rc.0"
+      }
+    },
+    {
       "version": "v2024.9.30",
       "hostDocs": true,
       "show": true,
@@ -441,7 +452,7 @@
       }
     }
   ],
-  "latestVersion": "v2024.9.30",
+  "latestVersion": "v2025.2.6-rc.0",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubevault",


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2025.2.6-rc.0
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/55