### PR TITLE
Update for release KubeStash@v2025.2.10

### DIFF
--- a/data/products/kubestash.json
+++ b/data/products/kubestash.json
@@ -177,6 +177,15 @@
       "show": true
     },
     {
+      "version": "v2025.2.10",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.15.0",
+        "installer": "v2025.2.10"
+      }
+    },
+    {
       "version": "v2025.2.6-rc.0",
       "hostDocs": true,
       "show": true,
@@ -266,7 +275,7 @@
       }
     }
   ],
-  "latestVersion": "v2025.2.6-rc.0",
+  "latestVersion": "v2025.2.10",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubestash",


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2025.2.10
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/26