### PR TITLE
Update for release KubeDB@v2025.2.19

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2025.2.19",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.37.0",
+        "cli": "v0.52.0",
+        "dashboard": "v0.28.0",
+        "installer": "v2025.2.19",
+        "ops-manager": "v0.39.0",
+        "provisioner": "v0.52.0",
+        "schema-manager": "v0.28.0",
+        "ui-server": "v0.28.0",
+        "webhook-server": "v0.28.0"
+      }
+    },
+    {
       "version": "v2025.2.6-rc.0",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2025.2.19
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/108