### PR TITLE
Update for release KubeDB@v2025.3.20-rc.1

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2025.3.20-rc.1",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.37.0-rc.1",
+        "cli": "v0.53.0-rc.1",
+        "dashboard": "v0.29.0-rc.1",
+        "installer": "v2025.3.20-rc.1",
+        "ops-manager": "v0.39.0-rc.1",
+        "provisioner": "v0.53.0-rc.1",
+        "schema-manager": "v0.29.0-rc.1",
+        "ui-server": "v0.29.0-rc.1",
+        "webhook-server": "v0.29.0-rc.1"
+      }
+    },
+    {
       "version": "v2025.2.19",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2025.3.20-rc.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/110