### PR TITLE
Update for release KubeDB@v2025.3.24

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2025.3.24",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.38.0",
+        "cli": "v0.53.0",
+        "dashboard": "v0.29.0",
+        "installer": "v2025.3.24",
+        "ops-manager": "v0.40.0",
+        "provisioner": "v0.53.0",
+        "schema-manager": "v0.29.0",
+        "ui-server": "v0.29.0",
+        "webhook-server": "v0.29.0"
+      }
+    },
+    {
       "version": "v2025.3.20-rc.1",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2025.3.24
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/111