### PR TITLE
Update for release KubeDB@v2025.5.30

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2025.5.30",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.40.0",
+        "cli": "v0.55.0",
+        "dashboard": "v0.31.0",
+        "installer": "v2025.5.30",
+        "ops-manager": "v0.42.0",
+        "provisioner": "v0.55.0",
+        "schema-manager": "v0.31.0",
+        "ui-server": "v0.31.0",
+        "webhook-server": "v0.31.0"
+      }
+    },
+    {
       "version": "v2025.4.30",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2025.5.30
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/113