### PR TITLE
Update for release KubeStash@v2025.7.31

### DIFF
--- a/data/products/kubestash.json
+++ b/data/products/kubestash.json
@@ -177,6 +177,15 @@
       "show": true
     },
     {
+      "version": "v2025.7.31",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.19.0",
+        "installer": "v2025.7.31"
+      }
+    },
+    {
       "version": "v2025.6.30",
       "hostDocs": true,
       "show": true,
@@ -309,7 +318,7 @@
       }
     }
   ],
-  "latestVersion": "v2025.6.30",
+  "latestVersion": "v2025.7.31",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubestash",


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2025.7.31
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/32