### PR TITLE
Update for release KubeDB@v2025.7.31

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2025.7.31",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.42.0",
+        "cli": "v0.57.0",
+        "dashboard": "v0.33.0",
+        "installer": "v2025.7.31",
+        "ops-manager": "v0.44.0",
+        "provisioner": "v0.57.0",
+        "schema-manager": "v0.33.0",
+        "ui-server": "v0.33.0",
+        "webhook-server": "v0.33.0"
+      }
+    },
+    {
       "version": "v2025.7.30-rc.0",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2025.7.31
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/116