### PR TITLE
Update for release KubeDB@v2025.8.31

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2025.8.31",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.43.0",
+        "cli": "v0.58.0",
+        "dashboard": "v0.34.0",
+        "installer": "v2025.8.31",
+        "ops-manager": "v0.45.0",
+        "provisioner": "v0.58.0",
+        "schema-manager": "v0.34.0",
+        "ui-server": "v0.34.0",
+        "webhook-server": "v0.34.0"
+      }
+    },
+    {
       "version": "v2025.7.31",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2025.8.31
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/118