### PR TITLE
Update for release KubeDB@v2025.12.9-rc.0

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2025.12.9-rc.0",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.45.0-rc.0",
+        "cli": "v0.60.0-rc.0",
+        "dashboard": "v0.36.0-rc.0",
+        "installer": "v2025.12.9-rc.0",
+        "ops-manager": "v0.47.0-rc.0",
+        "provisioner": "v0.60.0-rc.0",
+        "schema-manager": "v0.36.0-rc.0",
+        "ui-server": "v0.36.0-rc.0",
+        "webhook-server": "v0.36.0-rc.0"
+      }
+    },
+    {
       "version": "v2025.10.17",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2025.12.9-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/120