### PR TITLE
Update for release KubeDB@v2025.12.31-rc.1

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2025.12.31-rc.1",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.45.0-rc.1",
+        "cli": "v0.60.0-rc.1",
+        "dashboard": "v0.36.0-rc.1",
+        "installer": "v2025.12.31-rc.1",
+        "ops-manager": "v0.47.0-rc.1",
+        "provisioner": "v0.60.0-rc.1",
+        "schema-manager": "v0.36.0-rc.1",
+        "ui-server": "v0.36.0-rc.1",
+        "webhook-server": "v0.36.0-rc.1"
+      }
+    },
+    {
       "version": "v2025.12.9-rc.0",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2025.12.31-rc.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/123