### PR TITLE
Update for release KubeDB@v2026.1.19

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2026.1.19",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.45.0",
+        "cli": "v0.60.0",
+        "dashboard": "v0.36.0",
+        "installer": "v2026.1.19",
+        "ops-manager": "v0.47.0",
+        "provisioner": "v0.60.0",
+        "schema-manager": "v0.36.0",
+        "ui-server": "v0.36.0",
+        "webhook-server": "v0.36.0"
+      }
+    },
+    {
       "version": "v2025.12.31-rc.1",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2026.1.19
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/124