### PR TITLE
Update for release KubeDB@v2026.2.16-rc.0

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2026.2.16-rc.0",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.46.0-rc.0",
+        "cli": "v0.61.0-rc.0",
+        "dashboard": "v0.37.0-rc.0",
+        "installer": "v2026.2.16-rc.0",
+        "ops-manager": "v0.48.0-rc.0",
+        "provisioner": "v0.61.0-rc.0",
+        "schema-manager": "v0.37.0-rc.0",
+        "ui-server": "v0.37.0-rc.0",
+        "webhook-server": "v0.37.0-rc.0"
+      }
+    },
+    {
       "version": "v2026.1.19",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2026.2.16-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/125