### PR TITLE
Update for release KubeVault@v2026.2.27

### DIFF
--- a/data/products/kubevault.json
+++ b/data/products/kubevault.json
@@ -223,6 +223,17 @@
       "show": true
     },
     {
+      "version": "v2026.2.27",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.24.0",
+        "installer": "v2026.2.27",
+        "operator": "v0.24.0",
+        "unsealer": "v0.24.0"
+      }
+    },
+    {
       "version": "v2026.1.8-rc.0",
       "hostDocs": true,
       "show": true,
@@ -507,7 +518,7 @@
       }
     }
   ],
-  "latestVersion": "v2026.1.8-rc.0",
+  "latestVersion": "v2026.2.27",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubevault",


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2026.2.27
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/64