### PR TITLE
Update for release KubeDB@v2026.2.26

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2026.2.26",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.48.0",
+        "cli": "v0.63.0",
+        "dashboard": "v0.39.0",
+        "installer": "v2026.2.26",
+        "ops-manager": "v0.50.0",
+        "provisioner": "v0.63.0",
+        "schema-manager": "v0.39.0",
+        "ui-server": "v0.39.0",
+        "webhook-server": "v0.39.0"
+      }
+    },
+    {
       "version": "v2026.2.21-rc.1",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2026.2.26
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/129