### PR TITLE
Update CNCF member descriptions and remove Tinkerbell references

### DIFF
--- a/data/services/application-modernization/argo_cd_consulting_support.json
+++ b/data/services/application-modernization/argo_cd_consulting_support.json
@@ -246,7 +246,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "Pioneer in Kubernetes Services",
-        "description": "US-based pioneer in<a href=\"https://kubedb.com/\">Kubernetes service</a>, establishing early leadership across APAC."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -256,7 +256,7 @@
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
         "title": "CNCF Silver Member",
-        "description": "<a href=\"https://appscode.com/\">AppsCode </a> is a recognized <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and Kubernetes Certified Service Provider (KCSP)."
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-users",

--- a/data/services/application-modernization/build_devops_toolchain.json
+++ b/data/services/application-modernization/build_devops_toolchain.json
@@ -234,8 +234,8 @@
     "items": [
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Certified Provider",
-        "description": "<a href=\"https://appscode.com/\">AppsCode </a> is a <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and Kubernetes Certified Service Provider (KCSP)."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-users",
@@ -250,7 +250,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "First Mover Advantage",
-        "description": "US-based pioneer in<a href=\"https://kubedb.com/\">Kubernetes service</a>, establishing early leadership across APAC."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",

--- a/data/services/application-modernization/gitops_consulting.json
+++ b/data/services/application-modernization/gitops_consulting.json
@@ -279,8 +279,8 @@
     "items": [
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Certified Provider",
-        "description": "AppsCode is a <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and Kubernetes Certified Service Provider (KCSP)."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
@@ -300,7 +300,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "First Mover Advantage",
-        "description": "US-based pioneer in<a href=\"https://kubedb.com/\">Kubernetes service</a>, establishing early leadership across APAC."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-users",

--- a/data/services/application-modernization/jenkins_consulting_support.json
+++ b/data/services/application-modernization/jenkins_consulting_support.json
@@ -251,7 +251,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "First Mover Advantage",
-        "description": "US-based pioneer in<a href=\"https://kubedb.com/\">Kubernetes service</a>, establishing early leadership across APAC."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -260,8 +260,8 @@
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Certified Provider",
-        "description": "AppsCode is a <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and Kubernetes Certified Service Provider (KCSP)."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-users",

--- a/data/services/application-modernization/kubernetes_consulting_partner.json
+++ b/data/services/application-modernization/kubernetes_consulting_partner.json
@@ -260,7 +260,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "Industry Leadership",
-        "description": "AppsCode is one of the earliest Kubernetes consulting service providers in APAC."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -269,8 +269,8 @@
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Silver Member & KCSP",
-        "description": "AppsCode is officially recognized as a CNCF Silver Member and Kubernetes Certified Service Provider."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-users",

--- a/data/services/industries/automotive_cloud_native_devops_services.json
+++ b/data/services/industries/automotive_cloud_native_devops_services.json
@@ -271,7 +271,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "First Mover Advantage",
-        "description": "US-based pioneer in<a href=\"https://kubedb.com/\">Kubernetes service</a>, establishing early leadership across APAC."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -280,8 +280,8 @@
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Certified Provider",
-        "description": "AppsCode is a CNCF Silver Member & Kubernetes Certified Service Provider (KCSP)."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-users",

--- a/data/services/industries/banking_finance_cloud_native_devops_services.json
+++ b/data/services/industries/banking_finance_cloud_native_devops_services.json
@@ -275,7 +275,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "First Mover Advantage",
-        "description": "US-based pioneer in<a href=\"https://kubedb.com/\">Kubernetes service</a>, establishing early leadership across APAC."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -285,7 +285,7 @@
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
         "title": "CNCF Silver Member",
-        "description": "AppsCode is a CNCF Silver Member & Kubernetes Certified Service Provider (KCSP)."
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-users",

--- a/data/services/observability-devsecops/devsecops_consulting_services.json
+++ b/data/services/observability-devsecops/devsecops_consulting_services.json
@@ -243,7 +243,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "Early Kubernetes Adopter",
-        "description": "Among the earliest <a href=\"https://kubedb.com/\">Kubernetes service providers</a> in APAC, trusted for production-grade delivery."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -252,8 +252,8 @@
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Certified Provider",
-        "description": "AppsCode is a <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and Kubernetes Certified Service Provider (KCSP)."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-wrench",

--- a/data/services/observability-devsecops/grafana_consulting.json
+++ b/data/services/observability-devsecops/grafana_consulting.json
@@ -244,7 +244,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "Trusted Kubernetes & Observability Partner",
-        "description": "Among the earliest <a href=\"https://kubedb.com/\">Kubernetes Certified Service Providers</a> (KCSP) in the APAC region."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -254,7 +254,7 @@
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
         "title": "CNCF Silver Member",
-        "description": "Active contributor to the <a href=\"https://www.cncf.io/\">CNCF</a> ecosystem, advancing open-source innovation in observability and monitoring."
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-users",

--- a/data/services/observability-devsecops/observability_consulting.json
+++ b/data/services/observability-devsecops/observability_consulting.json
@@ -326,7 +326,7 @@
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
         "title": "Certified CNCF Member",
-        "description": "Appscode is a proud CNCF Silver Member and Kubernetes Certified Service Provider (KCSP)."
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-cloud",
@@ -361,7 +361,7 @@
     },
     {
       "question": "Which technologies and practices are used in observability consulting?",
-      "answer": "We leverage tools such as Prometheus, Grafana, Loki, Jaeger, OpenTelemetry, Kubernetes, and cloud-native monitoring solutions. Our approach ensures actionable insights, performance optimization, and reliable operations across complex systems."
+      "answer": "We leverage tools such as Prometheus, Thanos, ClickHouse, Perses, Jaeger, OpenTelemetry, Kubernetes, and cloud-native monitoring solutions. Our approach ensures actionable insights, performance optimization, and reliable operations across complex systems."
     },
     {
       "question": "Can you work with our existing applications and infrastructure?",

--- a/data/services/observability-devsecops/prometheus_monitoring_support.json
+++ b/data/services/observability-devsecops/prometheus_monitoring_support.json
@@ -254,7 +254,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "First Mover Advantage",
-        "description": "US-based pioneer in<a href=\"https://kubedb.com/\">Kubernetes service</a>, establishing early leadership across APAC."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -263,8 +263,8 @@
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Certified Provider",
-        "description": "<a href=\"https://appscode.com/\">AppsCode </a> is a proud <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and Kubernetes Certified Service Provider (KCSP)."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-users",

--- a/data/services/platform-engineering/backstage_consulting.json
+++ b/data/services/platform-engineering/backstage_consulting.json
@@ -271,7 +271,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "First Mover Advantage",
-        "description": "US-based pioneer in<a href=\"https://kubedb.com/\">Kubernetes service</a>, establishing early leadership across APAC."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -280,8 +280,8 @@
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Certified Provider",
-        "description": "CNCF Silver Member and Kubernetes Certified Service Provider (KCSP)."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-wrench",

--- a/data/services/platform-engineering/bare_metal_provisioning_consulting.json
+++ b/data/services/platform-engineering/bare_metal_provisioning_consulting.json
@@ -74,12 +74,12 @@
         "image": "/assets/images/services/customized-os-building-and-verification.png"
       },
       {
-        "title": "Tinkerbell Enterprise Support",
-        "description": "Scale or adopt Tinkerbell with guidance from engineers who contributed to its open-source development.",
+        "title": "KubeVirt Enterprise Support",
+        "description": "Scale or adopt KubeVirt with guidance from engineers who contributed to its open-source development.",
         "offerings": [
-          "Adoption Support: Step-by-step guidance for new Tinkerbell users.",
+          "Adoption Support: Step-by-step guidance for new KubeVirt users.",
           "Enterprise Assistance: Enterprise-grade support for production workloads.",
-          "Software Integration: Accelerate provisioning workflows with Tinkerbell tools and pipelines."
+          "Software Integration: Accelerate provisioning workflows with KubeVirt tools and pipelines."
         ],
         "image": "/assets/images/services/tinkerbell-enterprise-support.png"
       },
@@ -223,8 +223,8 @@
     ]
   },
   "final_cta": {
-    "title": "Enterprise-Grade Tinkerbell & On-Prem Support",
-    "subtitle": "Automate your bare metal provisioning confidently with 24/7 support from the engineers behind Tinkerbell.",
+    "title": "Enterprise-Grade KubeVirt & On-Prem Support",
+    "subtitle": "Automate your bare metal provisioning confidently with 24/7 support from the engineers behind KubeVirt.",
     "buttons": [
       {
         "text": "Discuss Enterprise Support",
@@ -249,7 +249,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "First Mover Advantage",
-        "description": "US-based pioneer in<a href=\"https://kubedb.com/\">Kubernetes service</a>, establishing early leadership across APAC"
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -258,8 +258,8 @@
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Certified Provider",
-        "description": "<a href=\"https://appscode.com/\">AppsCode </a> is a <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and Kubernetes Certified Service Provider (KCSP)."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-users",

--- a/data/services/platform-engineering/ci_cd_consulting.json
+++ b/data/services/platform-engineering/ci_cd_consulting.json
@@ -334,7 +334,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "First Mover Advantage",
-        "description": "US-based pioneer in<a href=\"https://kubedb.com/\">Kubernetes service</a>, establishing early leadership across APAC."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -343,8 +343,8 @@
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Certified Provider",
-        "description": "<a href=\"https://appscode.com/\">AppsCode </a> is a <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and Kubernetes Certified Service Provider (KCSP)."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-wrench",

--- a/data/services/platform-engineering/platform_engineering_services.json
+++ b/data/services/platform-engineering/platform_engineering_services.json
@@ -285,7 +285,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "First-Mover Advantage",
-        "description": "US-based pioneer in<a href=\"https://kubedb.com/\">Kubernetes service</a>, establishing early leadership across APAC."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -294,8 +294,8 @@
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Certified Provider",
-        "description": "Proud <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and Kubernetes Certified Service Provider (KCSP)."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-wrench",

--- a/data/services/platform-engineering/progressive_delivery_consulting.json
+++ b/data/services/platform-engineering/progressive_delivery_consulting.json
@@ -338,7 +338,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "First Mover Advantage",
-        "description": "US-based pioneer in<a href=\"https://kubedb.com/\">Kubernetes service</a>, establishing early leadership across APAC."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -347,8 +347,8 @@
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Certified Provider",
-        "description": "<a href=\"https://appscode.com/\">AppsCode </a> is a <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and Kubernetes Certified Service Provider."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-wrench",

--- a/data/services/product-engineering/cloud_native_faas.json
+++ b/data/services/product-engineering/cloud_native_faas.json
@@ -123,7 +123,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "Early Cloud Native Innovator",
-        "description": "Among the first in APAC to offer enterprise cloud native FaaS solutions."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -132,8 +132,8 @@
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Contributor",
-        "description": "AppsCode is a proud <a href=\"https://www.cncf.io/\">CNCF</a> contributor and Kubernetes Certified Service Provider (KCSP)."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-users",

--- a/data/services/product-engineering/cloud_native_product_development.json
+++ b/data/services/product-engineering/cloud_native_product_development.json
@@ -39,7 +39,7 @@
       {
         "icon": "fa fa-envelope-o",
         "title": "Reliable Cloud-Native Product Support",
-        "description": "Global support in APAC and EMEA to keep critical cloud-native systems healthy, secure, and performant in production."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-money",

--- a/data/services/product-engineering/monolith_to_microservices.json
+++ b/data/services/product-engineering/monolith_to_microservices.json
@@ -105,7 +105,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "Kubernetes & Microservices Pioneers",
-        "description": "Among the first in APAC to provide Kubernetes-based microservices and operator development."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-bullhorn",
@@ -114,8 +114,8 @@
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Silver Member & KCSP",
-        "description": "Recognized Kubernetes Certified Service Provider by CNCF."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-globe",
@@ -270,7 +270,7 @@
     },
     {
       "question": "Which technologies and practices do you use for Monolith to Microservices migration?",
-      "answer": "We leverage Kubernetes, Docker, API gateways, service meshes, and microservices frameworks to break down monolithic systems. Our practices include continuous delivery (CI/CD), Infrastructure as Code (IaC), observability, and DevOps automation to ensure smooth, low-risk migration."
+      "answer": "We leverage Kubernetes, Docker, Envoy Gateway, service meshes, and microservices frameworks to break down monolithic systems. Our practices include continuous delivery (CI/CD), Infrastructure as Code (IaC), observability, and DevOps automation to ensure smooth, low-risk migration."
     },
     {
       "question": "Can you modernize our existing monolithic application without a full rebuild?",

--- a/data/services/services_menu.json
+++ b/data/services/services_menu.json
@@ -37,12 +37,6 @@
           "icon": null
         },
         {
-          "id": "cloud-native-platform-engineering-architecture-eBook",
-          "title": "Platform Engineering OSS Reference Architecture eBook",
-          "description": "Building a Platform? Refer to the Platform Engineering OSS Reference Architecture eBook to get started — Download the 22 page eBook",
-          "icon": null
-        },
-        {
           "id": "progressive-delivery-consulting-services",
           "title": "Progressive Delivery",
           "description": "Roll out updates strategically",
@@ -175,25 +169,6 @@
           "id": "prometheus-consulting-services",
           "title": "Prometheus Consulting",
           "description": "Monitoring & alerting ‑ sorted!",
-          "icon": null
-        }
-      ]
-    },
-    {
-      "title": "Industries",
-      "description": "Solutions tailored for industries",
-      "icon": "https://img.icons8.com/00a651/external-obvious-line-kerismaker/96/external-building-manufacturing-line-obvious-line-kerismaker-2.png",
-      "offerings": [
-        {
-          "id": "cloud-native-solutions-for-the-banking-and-finance-industry",
-          "title": "Banking and Finance",
-          "description": "Navigate evolving risks with cutting‑edge solutions",
-          "icon": null
-        },
-        {
-          "id": "cloud-native-solutions-for-the-automotive-industry",
-          "title": "Automotive",
-          "description": "From garage to cloud ‑ AutoTech evolution",
           "icon": null
         }
       ]

--- a/data/services/site-reliability-engineering/cloud_native_networking_services.json
+++ b/data/services/site-reliability-engineering/cloud_native_networking_services.json
@@ -141,7 +141,7 @@
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
         "title": "CNCF Silver Member",
-        "description": "Proud member of the Cloud Native Computing Foundation and Kubernetes Certified Service Provider (KCSP)."
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-users",
@@ -285,7 +285,7 @@
     },
     {
       "question": "Which technologies and practices are used in cloud-native networking?",
-      "answer": "We leverage Kubernetes networking, service meshes like Istio and Linkerd, Envoy proxies, CNI plugins, cloud provider networking services, and observability tools. Our approach ensures secure, reliable, and high-performance connectivity across cloud-native environments."
+      "answer": "We leverage Kubernetes networking, service meshes like Istio, Envoy proxies, CNI plugins, cloud provider networking services, and observability tools. Our approach ensures secure, reliable, and high-performance connectivity across cloud-native environments."
     },
     {
       "question": "Can you work with our existing cloud infrastructure and applications?",

--- a/data/services/site-reliability-engineering/istio_consulting.json
+++ b/data/services/site-reliability-engineering/istio_consulting.json
@@ -120,7 +120,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "Early Adopter",
-        "description": "US-based pioneer in<a href=\"https://kubedb.com/\">Kubernetes service</a>, establishing early leadership across APAC."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -129,8 +129,8 @@
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Certified Provider",
-        "description": "<a href=\"https://appscode.com/\">AppsCode </a> is a CNCF Silver Member & Kubernetes Certified Service Provider (KCSP)."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-wrench",

--- a/data/services/site-reliability-engineering/kubernetes_disaster_recovery.json
+++ b/data/services/site-reliability-engineering/kubernetes_disaster_recovery.json
@@ -94,7 +94,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "Pioneer in Kubernetes Services",
-        "description": "One of the earliest <a href=\"https://kubedb.com/\">Kubernetes service providers</a> in APAC with years of production-grade experience."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-bullhorn",
@@ -103,8 +103,8 @@
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Certified Provider",
-        "description": "<a href=\"https://appscode.com/\">AppsCode </a> is a proud <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a Kubernetes Certified Service Provider (KCSP)."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-globe",
@@ -268,7 +268,7 @@
     },
     {
       "question": "Which technologies and practices are used in Kubernetes backup and disaster recovery?",
-      "answer": "We leverage tools like Velero, Stash, Kasten K10, cloud provider snapshot services, and Kubernetes-native solutions. Our approach includes automated backups, scheduled restores, data integrity verification, and failover strategies to maintain resilient and reliable clusters."
+      "answer": "We leverage tools like KubeStash, cloud provider snapshot services, and Kubernetes-native solutions. Our approach includes automated backups, scheduled restores, data integrity verification, and failover strategies to maintain resilient and reliable clusters."
     },
     {
       "question": "Can you work with our existing Kubernetes infrastructure and workloads?",

--- a/data/services/site-reliability-engineering/service_mesh_consulting.json
+++ b/data/services/site-reliability-engineering/service_mesh_consulting.json
@@ -100,8 +100,8 @@
     "items": [
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Certified Provider",
-        "description": "AppsCode is a proud <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and Kubernetes Certified Service Provider (KCSP)."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-users",
@@ -121,7 +121,7 @@
       {
         "icon": "fa fa-graduation-cap",
         "title": "Pioneers in Kubernetes",
-        "description": "US-based pioneer in<a href=\"https://kubedb.com/\">Kubernetes service</a>, establishing early leadership across APAC."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-wrench",

--- a/data/services/site-reliability-engineering/sre_consulting_services.json
+++ b/data/services/site-reliability-engineering/sre_consulting_services.json
@@ -137,7 +137,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "First Mover Advantage",
-        "description": "US-based pioneer in<a href=\"https://kubedb.com/\">Kubernetes service</a>, establishing early leadership across APAC."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -146,8 +146,8 @@
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Certified Provider",
-        "description": "AppsCode is a <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and Kubernetes Certified Service Provider (KCSP)."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-wrench",

--- a/data/services/site-reliability-engineering/terraform_consulting.json
+++ b/data/services/site-reliability-engineering/terraform_consulting.json
@@ -154,7 +154,7 @@
       {
         "icon": "fa fa-trophy",
         "title": "Kubernetes First Movers",
-        "description": "Among the earliest <a href=\"https://kubedb.com/\">Kubernetes service providers</a> in APAC with years of field expertise."
+        "description": "US-based pioneer in Kubernetes products and services with years of field expertise."
       },
       {
         "icon": "fa fa-graduation-cap",
@@ -163,8 +163,8 @@
       },
       {
         "logo": "https://img.icons8.com/00a651/ios-glyphs/30/certificate.png",
-        "title": "CNCF Certified Provider",
-        "description": "<a href=\"https://appscode.com/\">AppsCode </a> is a <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and an official Kubernetes Certified Service Provider (KCSP)."
+        "title": "CNCF Silver Member",
+        "description": "A <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and a regular sponsor of KubeCon + CloudNativeCon."
       },
       {
         "icon": "fa fa-users",


### PR DESCRIPTION
## Summary
- Update CNCF member descriptions across service pages (change "CNCF Certified Provider" to "CNCF Member" with updated copy)
- Replace Tinkerbell references with KubeVirt in bare metal provisioning consulting
- Remove Industries section and Platform Engineering eBook from services menu