### PR TITLE
Remove open_source section from service JSON files

### DIFF
--- a/data/services/application-modernization/aks_consulting_partner.json
+++ b/data/services/application-modernization/aks_consulting_partner.json
@@ -142,15 +142,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Built on Open Source, Powered by Community",
-    "description": "AppsCode actively contributes to CNCF and open-source projects such as <a href=\"https://kubedb.com/\">KubeDB</a>, <a href=\"https://kubevault.com/\">KubeVault</a>, <a href=\"https://stash.run/\">Stash</a>, and <a href=\"https://voyagermesh.com/\">Voyager</a> — all deployable on Azure AKS and available on the <a href=\"https://azuremarketplace.microsoft.com/en-us/marketplace/apps/appscode.ace_payg\">Azure Marketplace</a>.",
-    "cta_text": "Explore Our Open Source Projects",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Our AKS Technology Expertise",
     "subtitle": "We use proven cloud-native tools and frameworks to deliver enterprise-grade AKS consulting services.",

--- a/data/services/application-modernization/argo_cd_consulting_support.json
+++ b/data/services/application-modernization/argo_cd_consulting_support.json
@@ -127,15 +127,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "We Power Open Source and GitOps Innovation",
-    "description": "As active contributors to CNCF projects, our engineers help advance open-source GitOps and Kubernetes ecosystems, integrating tools like Argo CD, Crossplane, and Prometheus.",
-    "cta_text": "Explore Our Open Source Contributions",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Technical Expertise",
     "subtitle": "Our certified Kubernetes consultants excel in:",

--- a/data/services/application-modernization/build_devops_toolchain.json
+++ b/data/services/application-modernization/build_devops_toolchain.json
@@ -127,15 +127,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "We Love Open Source",
-    "description": "Our developers contribute to cloud-native projects and create OSS solutions to empower the tech community.",
-    "cta_text": "Explore Our OSS Contributions",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Technical Expertise",
     "subtitle": "Our certified engineers excel in:",

--- a/data/services/application-modernization/eks_consulting_partner.json
+++ b/data/services/application-modernization/eks_consulting_partner.json
@@ -142,15 +142,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Built on Open Source, Powered by Community",
-    "description": "AppsCode actively contributes to CNCF and open-source projects such as <a href=\"https://kubedb.com/\">KubeDB</a>, <a href=\"https://kubevault.com/\">KubeVault</a>, <a href=\"https://stash.run/\">Stash</a>, and <a href=\"https://voyagermesh.com/\">Voyager</a> — all deployable on Amazon EKS and available on the <a href=\"https://aws.amazon.com/marketplace/seller-profile?id=seller-6nyynzztrttiq\">AWS Marketplace</a>.",
-    "cta_text": "Explore Our Open Source Projects",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Our EKS Technology Expertise",
     "subtitle": "We use proven cloud-native tools and frameworks to deliver enterprise-grade EKS consulting services.",

--- a/data/services/application-modernization/gitops_consulting.json
+++ b/data/services/application-modernization/gitops_consulting.json
@@ -137,15 +137,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Empowering the Open Source Ecosystem",
-    "description": "AppsCode contributes to and maintains several open-source projects like <a href=\"https://kubedb.com/\">KubeDB</a>, <a href=\"https://kubevault.com/\">KubeVault,</a> <a href=\"https://stash.run/\">Stash,</a> and <a href=\"https://voyagermesh.com/\">Voyager</a> — enhancing the GitOps and Kubernetes ecosystem.",
-    "cta_text": "Explore Our Open Source Projects",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "OAppsCode Open Source GitOps Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Diverse Technical Expertise",
     "subtitle": "Our certified engineers excel in:",

--- a/data/services/application-modernization/gke_consulting_partner.json
+++ b/data/services/application-modernization/gke_consulting_partner.json
@@ -142,15 +142,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Built on Open Source, Powered by Community",
-    "description": "AppsCode actively contributes to CNCF and open-source projects such as <a href=\"https://kubedb.com/\">KubeDB</a>, <a href=\"https://kubevault.com/\">KubeVault</a>, <a href=\"https://stash.run/\">Stash</a>, and <a href=\"https://voyagermesh.com/\">Voyager</a> — all deployable on Google GKE.",
-    "cta_text": "Explore Our Open Source Projects",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Our GKE Technology Expertise",
     "subtitle": "We use proven cloud-native tools and frameworks to deliver enterprise-grade GKE consulting services.",

--- a/data/services/application-modernization/jenkins_consulting_support.json
+++ b/data/services/application-modernization/jenkins_consulting_support.json
@@ -133,15 +133,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Open Source Leadership",
-    "description": "AppsCode contributes to cloud-native open-source projects and leverages them to deliver innovative Jenkins automation and CI/CD solutions.",
-    "cta_text": "Explore Our Open Source Projects",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions by AppsCode"
-    }
-  },
   "tech_stack": {
     "title": "Diverse Technical Expertise",
     "subtitle": "Our certified consultants are skilled in:",

--- a/data/services/application-modernization/kubernetes_consulting_partner.json
+++ b/data/services/application-modernization/kubernetes_consulting_partner.json
@@ -142,15 +142,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Built on Open Source, Powered by Community",
-    "description": "AppsCode actively contributes to CNCF and open-source projects such as <a href=\"https://kubedb.com/\">KubeDB</a>, <a href=\"https://kubevault.com/\">KubeVault,</a> <a href=\"https://stash.run/\">Stash,</a> and <a href=\"https://voyagermesh.com/\">Voyager</a> — empowering the Kubernetes ecosystem worldwide.",
-    "cta_text": "Explore Our Open Source Projects",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Our Kubernetes Technology Expertise",
     "subtitle": "We use proven cloud-native tools and frameworks to deliver enterprise-grade Kubernetes consulting services.",

--- a/data/services/application-modernization/openshift_consulting_partner.json
+++ b/data/services/application-modernization/openshift_consulting_partner.json
@@ -142,15 +142,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Built on Open Source, Powered by Community",
-    "description": "AppsCode actively contributes to CNCF and open-source projects such as <a href=\"https://kubedb.com/\">KubeDB</a>, <a href=\"https://kubevault.com/\">KubeVault</a>, <a href=\"https://stash.run/\">Stash</a>, and <a href=\"https://voyagermesh.com/\">Voyager</a> — all certified on Red Hat OpenShift and available in the <a href=\"https://catalog.redhat.com/en/platform/red-hat-openshift\">Red Hat Ecosystem Catalog</a>.",
-    "cta_text": "Explore Our Open Source Projects",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Our OpenShift Technology Expertise",
     "subtitle": "We use proven cloud-native tools and frameworks to deliver enterprise-grade OpenShift consulting services.",

--- a/data/services/application-modernization/rancher_consulting_partner.json
+++ b/data/services/application-modernization/rancher_consulting_partner.json
@@ -142,15 +142,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Built on Open Source, Powered by Community",
-    "description": "AppsCode actively contributes to CNCF and open-source projects such as <a href=\"https://kubedb.com/\">KubeDB</a>, <a href=\"https://kubevault.com/\">KubeVault</a>, <a href=\"https://stash.run/\">Stash</a>, and <a href=\"https://voyagermesh.com/\">Voyager</a> — all available as Rancher Partner Charts in the <a href=\"https://github.com/rancher/partner-charts\">SUSE Rancher ecosystem</a>.",
-    "cta_text": "Explore Our Open Source Projects",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Our Rancher Technology Expertise",
     "subtitle": "We use proven cloud-native tools and frameworks to deliver enterprise-grade Rancher consulting services.",

--- a/data/services/industries/automotive_cloud_native_devops_services.json
+++ b/data/services/industries/automotive_cloud_native_devops_services.json
@@ -153,15 +153,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Open Source Contributions",
-    "description": "<a href=\"https://appscode.com/\">AppsCode </a> contributes to cloud-native projects like Kubernetes and Prometheus, leveraging OSS to build reliable automotive platforms.",
-    "cta_text": "Explore Our OSS Work",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Automotive Cloud-Native Tech Stack",
     "subtitle": "Certified engineers with expertise in Kubernetes, observability, DevSecOps, and cloud-native tools for automotive workloads.",

--- a/data/services/industries/banking_finance_cloud_native_devops_services.json
+++ b/data/services/industries/banking_finance_cloud_native_devops_services.json
@@ -157,15 +157,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Proud Open Source Contributors",
-    "description": "<a href=\"https://appscode.com/\">AppsCode </a> actively contributes to <a href=\"https://www.cncf.io/\">CNCF</a> projects like <a href=\"https://kubernetes.io/\">Kubernetes</a>, <a href=\"https://appscode.com/services/prometheus-consulting-services/\">Prometheus</a>, and <a href=\"https://kubevault.com/\">KubeVault</a> — helping financial organizations build on proven, open-source technologies.",
-    "cta_text": "View Our Open Source Contributions",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Our Cloud-Native Tech Stack Expertise",
     "subtitle": "Certified engineers with deep experience in Kubernetes, observability, and cloud security tools for banking-grade workloads.",

--- a/data/services/managed_cloud/managed_aws.json
+++ b/data/services/managed_cloud/managed_aws.json
@@ -142,15 +142,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Built on Open Source, Powered by Community",
-    "description": "AppsCode develops and maintains open-source Kubernetes operators including <a href=\"https://kubedb.com/\">KubeDB</a>, <a href=\"https://kubestash.com/\">KubeStash</a>, and <a href=\"https://voyagermesh.com/\">Voyager</a> — all deployable on AWS. We are a <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and listed on the <a href=\"https://aws.amazon.com/marketplace/seller-profile?id=seller-6nyynzztrttiq\">AWS Marketplace</a>.",
-    "cta_text": "Explore Our Open Source Projects",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Our AWS Technology Expertise",
     "subtitle": "We use the full AWS ecosystem and cloud-native tools to deliver enterprise-grade managed cloud services.",

--- a/data/services/managed_cloud/managed_azure.json
+++ b/data/services/managed_cloud/managed_azure.json
@@ -142,15 +142,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Built on Open Source, Powered by Community",
-    "description": "AppsCode develops and maintains open-source Kubernetes operators including <a href=\"https://kubedb.com/\">KubeDB</a>, <a href=\"https://kubestash.com/\">KubeStash</a>, and <a href=\"https://voyagermesh.com/\">Voyager</a> — all deployable on Azure. We are a <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and listed on the <a href=\"https://azuremarketplace.microsoft.com/en-us/marketplace/apps/appscode.ace_payg\">Azure Marketplace</a>.",
-    "cta_text": "Explore Our Open Source Projects",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Our Azure Technology Expertise",
     "subtitle": "We use the full Azure ecosystem and cloud-native tools to deliver enterprise-grade managed cloud services.",

--- a/data/services/managed_cloud/managed_gcp.json
+++ b/data/services/managed_cloud/managed_gcp.json
@@ -142,15 +142,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Built on Open Source, Powered by Community",
-    "description": "AppsCode develops and maintains open-source Kubernetes operators including <a href=\"https://kubedb.com/\">KubeDB</a>, <a href=\"https://kubestash.com/\">KubeStash</a>, and <a href=\"https://voyagermesh.com/\">Voyager</a> — all deployable on GCP. We are a <a href=\"https://www.cncf.io/\">CNCF</a> Silver Member and GKE-ready.",
-    "cta_text": "Explore Our Open Source Projects",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Our GCP Technology Expertise",
     "subtitle": "We use the full Google Cloud ecosystem and cloud-native tools to deliver enterprise-grade managed cloud services.",

--- a/data/services/managed_databases.json
+++ b/data/services/managed_databases.json
@@ -144,15 +144,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Built on Open Source, Powered by Community",
-    "description": "AppsCode develops and maintains <a href=\"https://kubedb.com/\">KubeDB</a>, <a href=\"https://kubestash.com/\">KubeStash</a>, and <a href=\"https://kubevault.com/\">KubeVault</a> — all open-core projects with Apache v2 licensed APIs. KubeDB is a <a href=\"https://operatorhub.io/operator/kubedb-installer\">certified Operator on OperatorHub</a> and a <a href=\"https://www.cncf.io/\">CNCF</a> ecosystem project.",
-    "cta_text": "Explore Our Open Source Projects",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions by AppsCode"
-    }
-  },
   "tech_stack": {
     "title": "Our Database Technology Expertise",
     "subtitle": "We manage 25+ database engines on Kubernetes using KubeDB — the most comprehensive Kubernetes-native database operator.",

--- a/data/services/observability-devsecops/devsecops_consulting_services.json
+++ b/data/services/observability-devsecops/devsecops_consulting_services.json
@@ -136,15 +136,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Open Source-Driven DevSecOps Innovation",
-    "description": "<a href=\"https://appscode.com/\">AppsCode </a> actively contributes to open-source DevSecOps tools and cloud-native security frameworks, empowering teams to secure and scale faster.",
-    "cta_text": "Explore Our Open Source Work",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "AppsCode Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Expertise Across Leading DevSecOps Tools & Frameworks",
     "subtitle": "Our certified engineers bring hands-on experience with the top open-source and enterprise-grade security tools.",

--- a/data/services/observability-devsecops/grafana_consulting.json
+++ b/data/services/observability-devsecops/grafana_consulting.json
@@ -126,15 +126,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Open Source & Grafana Community Contributions",
-    "description": "Appscode’s engineers actively contribute to leading open-source observability projects, extending Grafana’s ecosystem with innovative integrations and solutions.",
-    "cta_text": "Explore Our Open Source Contributions",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Appscode Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Deep Technical Expertise in the Grafana Ecosystem",
     "subtitle": "Appscode’s consulting team builds secure, scalable observability stacks using industry-leading open-source tools.",

--- a/data/services/observability-devsecops/observability_consulting.json
+++ b/data/services/observability-devsecops/observability_consulting.json
@@ -122,15 +122,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Built on Open Source Excellence",
-    "description": "Appscode is a <a href=\"https://www.cncf.io/\">CNCF</a>Silver Member and active contributor to the Kubernetes ecosystem. We believe in the power of open source to drive transparency, innovation, and long-term scalability.",
-    "cta_text": "Explore Our Open Source Contributions",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Appscode Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Our Observability Tech Stack Expertise",
     "subtitle": "We integrate leading open-source and enterprise tools to deliver robust, scalable observability platforms.",

--- a/data/services/observability-devsecops/prometheus_monitoring_support.json
+++ b/data/services/observability-devsecops/prometheus_monitoring_support.json
@@ -136,15 +136,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "We Build and Contribute to Open Source",
-    "description": "At Appscode, open source fuels everything we do. Our engineers contribute to major cloud-native and observability projects, extending the Prometheus ecosystem for community and enterprise innovation.",
-    "cta_text": "Explore Our Open Source Contributions",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Appscode Prometheus Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Diverse Technical Expertise",
     "subtitle": "Serving 100+ customers, our engineers have expertise across cloud-native and security tools.",

--- a/data/services/platform-engineering/backstage_consulting.json
+++ b/data/services/platform-engineering/backstage_consulting.json
@@ -164,15 +164,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Open Source Contributions",
-    "description": "AppsCode contributes actively to cloud-native projects and leverages open-source tools to develop efficient, scalable Backstage solutions.",
-    "cta_text": "View Our OSS Contributions",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions for Backstage"
-    }
-  },
   "tech_stack": {
     "title": "Technical Expertise for Backstage",
     "subtitle": "Hands-on experience with modern cloud-native technologies to build scalable and robust IDPs.",

--- a/data/services/platform-engineering/bare_metal_provisioning_consulting.json
+++ b/data/services/platform-engineering/bare_metal_provisioning_consulting.json
@@ -131,15 +131,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "We Love Open Source",
-    "description": "Our developers contribute to cloud-native projects and leverage open-source solutions to build innovative products.",
-    "cta_text": "Explore Our OSS Contributions",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Our Technical Expertise",
     "subtitle": "Our engineers have hands-on experience with over 100 clients in the following technologies:",

--- a/data/services/platform-engineering/ci_cd_consulting.json
+++ b/data/services/platform-engineering/ci_cd_consulting.json
@@ -216,15 +216,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Open Source Contributions",
-    "description": "We actively contribute to cloud-native projects and leverage OSS to build innovative CI/CD solutions.",
-    "cta_text": "Explore Our Open Source Contributions",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Diverse Technical Expertise",
     "subtitle": "Serving 100+ clients, our engineers excel in:",

--- a/data/services/platform-engineering/platform_engineering_services.json
+++ b/data/services/platform-engineering/platform_engineering_services.json
@@ -178,15 +178,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Passionate About Open Source",
-    "description": "AppsCode actively contributes to cloud-native projects, leveraging open-source innovations to create better, more efficient platforms for our clients.",
-    "cta_text": "Explore Our OSS Contributions",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Technical Expertise for Modern Platforms",
     "subtitle": "Hands-on experience with cloud-native and Kubernetes-based tools to deliver scalable and secure platform engineering services.",

--- a/data/services/platform-engineering/progressive_delivery_consulting.json
+++ b/data/services/platform-engineering/progressive_delivery_consulting.json
@@ -220,15 +220,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "We Love Open Source",
-    "description": "Our developers contribute to cloud-native projects and leverage OSS to build innovative solutions.",
-    "cta_text": "Sneak Peek at Our OSS Contributions",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Diverse Technical Expertise",
     "subtitle": "Our engineers have hands-on experience with modern cloud-native technologies to enable successful progressive delivery adoption.",

--- a/data/services/product-engineering/cloud_native_faas.json
+++ b/data/services/product-engineering/cloud_native_faas.json
@@ -179,15 +179,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Innovation Through Open Source",
-    "description": "AppsCode actively contributes to Kubernetes, Knative, OpenFaaS, and cloud native ecosystems—driving FaaS innovation through community collaboration.",
-    "cta_text": "Explore Our Open Source Projects",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Cloud Native FaaS Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Technologies We Excel In",
     "subtitle": "Our engineers master modern serverless and cloud-native tools to build scalable, future-ready architectures.",

--- a/data/services/product-engineering/cloud_native_product_development.json
+++ b/data/services/product-engineering/cloud_native_product_development.json
@@ -237,15 +237,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Driving Cloud Native Innovation Through Open Source",
-    "description": "As a contributor to <a href=\"https://kubernetes.io/\">Kubernetes</a> and related open-source ecosystems, AppsCode Inc. helps enterprises build cloud-native solutions using community-driven innovation and proven DevOps tooling.",
-    "cta_text": "Explore Our Open Source Contributions",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Cloud Native Open Source Contributions by AppsCode"
-    }
-  },
   "tech_stack": {
     "title": "Comprehensive Cloud-Native Tech Expertise",
     "subtitle": "Our engineering teams work across the languages, frameworks, and platforms that power modern cloud-native solutions:",

--- a/data/services/product-engineering/monolith_to_microservices.json
+++ b/data/services/product-engineering/monolith_to_microservices.json
@@ -161,15 +161,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Built on Open Source. Driven by Innovation.",
-    "description": "Appscode engineers contribute to leading Kubernetes and cloud-native open-source projects, bringing deep practical knowledge to every microservices engagement.",
-    "cta_text": "Explore Our Open Source Projects",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Microservices Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Our Cloud-Native & Microservices Tech Expertise",
     "subtitle": "Appscode engineers leverage Kubernetes, DevOps tools, and open-source frameworks to deliver modern, scalable microservices architectures.",

--- a/data/services/site-reliability-engineering/cloud_native_networking_services.json
+++ b/data/services/site-reliability-engineering/cloud_native_networking_services.json
@@ -187,15 +187,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "We Love Open Source",
-    "description": "Open source is in our DNA. <a href=\"https://appscode.com/\">AppsCode </a> actively contributes to the cloud-native ecosystem — creating, maintaining, and improving OSS projects that empower developers and enterprises globally.",
-    "cta_text": "Explore Our OSS Contributions",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "We Love Open Source"
-    }
-  },
   "tech_stack": {
     "title": "Deep Expertise Across Cloud-Native Networking Technologies",
     "subtitle": "Our engineers bring hands-on experience with the most popular CNIs, service meshes, and networking frameworks.",

--- a/data/services/site-reliability-engineering/istio_consulting.json
+++ b/data/services/site-reliability-engineering/istio_consulting.json
@@ -176,15 +176,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Built on Open Source Values",
-    "description": "We’re proud contributors to <a href=\"https://www.cncf.io/\">CNCF</a> and Istio ecosystem. Open source fuels our innovation and yours.",
-    "cta_text": "See Our OSS Contributions",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "We Love Open Source"
-    }
-  },
   "tech_stack": {
     "title": "Our Istio Tech Stack Expertise",
     "subtitle": "Certified consultants experienced with leading service mesh and observability tools.",

--- a/data/services/site-reliability-engineering/kubernetes_disaster_recovery.json
+++ b/data/services/site-reliability-engineering/kubernetes_disaster_recovery.json
@@ -150,15 +150,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Powered by Open Source Innovation",
-    "description": "Open source is at the heart of everything we do. Our teams contribute to leading cloud-native projects and develop OSS solutions that empower developers worldwide.",
-    "cta_text": "Explore Our Open Source Contributions",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "AppsCode Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Broad Technical Expertise Across the Cloud Native Ecosystem",
     "subtitle": "Our engineers bring hands-on experience with modern tools, platforms, and frameworks gained through 100+ production deployments.",

--- a/data/services/site-reliability-engineering/service_mesh_consulting.json
+++ b/data/services/site-reliability-engineering/service_mesh_consulting.json
@@ -167,15 +167,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "We’re Built on Open Source",
-    "description": "Our DNA is open source. We actively contribute to the cloud-native ecosystem and build new OSS tools for the community.",
-    "cta_text": "Explore Our OSS Contributions",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Choosing the Right Service Mesh — Simplified",
     "subtitle": "We help you evaluate, deploy, and manage the best-fit mesh for your workloads.",

--- a/data/services/site-reliability-engineering/sre_consulting_services.json
+++ b/data/services/site-reliability-engineering/sre_consulting_services.json
@@ -193,15 +193,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Open Source Contributions",
-    "description": "Our engineers actively contribute to cloud-native OSS projects and leverage open-source tools to deliver innovative SRE solutions.",
-    "cta_text": "Explore Our OSS Projects",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "Open Source Contributions"
-    }
-  },
   "tech_stack": {
     "title": "Diverse Technical Expertise",
     "subtitle": "Our engineers are proficient in:",

--- a/data/services/site-reliability-engineering/terraform_consulting.json
+++ b/data/services/site-reliability-engineering/terraform_consulting.json
@@ -210,15 +210,6 @@
       }
     ]
   },
-  "open_source": {
-    "title": "Powered by Open Source",
-    "description": "We believe open source drives innovation. Our engineers actively contribute to major cloud-native projects and build new OSS tools for the community.",
-    "cta_text": "Explore Our Open Source Work",
-    "image": {
-      "src": "/assets/images/services/open-source.png",
-      "alt": "We Love Open Source"
-    }
-  },
   "tech_stack": {
     "title": "Our Technical Expertise",
     "subtitle": "With experience across 100+ global projects, our team masters a broad cloud-native tech stack.",


### PR DESCRIPTION
## Summary
- Removed `open_source` key from all 34 JSON files under `data/services/`
- Each file had a 9-line section containing title, description, cta_text, and image fields