### PR TITLE
Update for release KubeDB@v2026.4.13-rc.0

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2026.4.13-rc.0",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.49.0-rc.0",
+        "cli": "v0.64.0-rc.0",
+        "dashboard": "v0.40.0-rc.0",
+        "installer": "v2026.4.13-rc.0",
+        "ops-manager": "v0.51.0-rc.0",
+        "provisioner": "v0.64.0-rc.0",
+        "schema-manager": "v0.40.0-rc.0",
+        "ui-server": "v0.40.0-rc.0",
+        "webhook-server": "v0.40.0-rc.0"
+      }
+    },
+    {
       "version": "v2026.2.26",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2026.4.13-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/130