### PR TITLE
chore(products): disable host docs for versions older than 2 years

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -622,7 +622,7 @@
     },
     {
       "version": "v2024.3.16",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.29.0",
@@ -638,7 +638,7 @@
     },
     {
       "version": "v2024.3.9-rc.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.28.0-rc.0",
         "cli": "v0.43.0-rc.0",
@@ -653,7 +653,7 @@
     },
     {
       "version": "v2024.2.14",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.27.0",
@@ -669,7 +669,7 @@
     },
     {
       "version": "v2024.1.31",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.26.0",
@@ -685,7 +685,7 @@
     },
     {
       "version": "v2024.1.28-rc.1",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.26.0-rc.1",
         "cli": "v0.41.0-rc.1",
@@ -700,7 +700,7 @@
     },
     {
       "version": "v2024.1.26-rc.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.26.0-rc.0",
         "cli": "v0.41.0-rc.0",
@@ -715,7 +715,7 @@
     },
     {
       "version": "v2024.1.19-beta.1",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.26.0-beta.1",
         "cli": "v0.41.0-beta.1",
@@ -730,7 +730,7 @@
     },
     {
       "version": "v2024.1.7-beta.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.26.0-beta.0",
         "cli": "v0.41.0-beta.0",
@@ -745,7 +745,7 @@
     },
     {
       "version": "v2023.12.28",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.25.0",
@@ -761,7 +761,7 @@
     },
     {
       "version": "v2023.12.21",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.24.0",
         "cli": "v0.39.0",
@@ -776,7 +776,7 @@
     },
     {
       "version": "v2023.12.11",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.23.0",
@@ -792,7 +792,7 @@
     },
     {
       "version": "v2023.12.1-rc.1",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.23.0-rc.1",
         "cli": "v0.38.0-rc.1",
@@ -807,7 +807,7 @@
     },
     {
       "version": "v2023.11.29-rc.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.23.0-rc.0",
         "cli": "v0.38.0-rc.0",
@@ -822,7 +822,7 @@
     },
     {
       "version": "v2023.11.2",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.22.0",
@@ -838,7 +838,7 @@
     },
     {
       "version": "v2023.10.9",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.21.0",
@@ -854,7 +854,7 @@
     },
     {
       "version": "v2023.08.18",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.20.0",
@@ -870,7 +870,7 @@
     },
     {
       "version": "v2023.06.19",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.19.0",
@@ -886,7 +886,7 @@
     },
     {
       "version": "v2023.06.13-rc.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.19.0-rc.0",
         "cli": "v0.34.0-rc.0",
@@ -901,7 +901,7 @@
     },
     {
       "version": "v2023.04.10",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.18.0",
@@ -917,7 +917,7 @@
     },
     {
       "version": "v2023.02.28",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.17.0",
@@ -933,7 +933,7 @@
     },
     {
       "version": "v2023.01.31",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.16.0",
@@ -949,7 +949,7 @@
     },
     {
       "version": "v2023.01.17",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.15.1",
@@ -965,7 +965,7 @@
     },
     {
       "version": "v2022.12.28",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.15.0",
@@ -981,7 +981,7 @@
     },
     {
       "version": "v2022.12.24-rc.1",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.15.0-rc.1",
         "cli": "v0.30.0-rc.1",
@@ -996,7 +996,7 @@
     },
     {
       "version": "v2022.12.13-rc.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.15.0-rc.0",
         "cli": "v0.30.0-rc.0",
@@ -1011,7 +1011,7 @@
     },
     {
       "version": "v2022.10.18",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.14.0",
@@ -1027,7 +1027,7 @@
     },
     {
       "version": "v2022.10.12-rc.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.14.0-rc.0",
         "cli": "v0.29.0-rc.0",
@@ -1042,7 +1042,7 @@
     },
     {
       "version": "v2022.08.08",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.13.0",
@@ -1058,7 +1058,7 @@
     },
     {
       "version": "v2022.08.04-rc.1",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.13.0-rc.1",
         "cli": "v0.28.0-rc.1",
@@ -1073,7 +1073,7 @@
     },
     {
       "version": "v2022.08.02-rc.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.13.0-rc.0",
         "cli": "v0.28.0-rc.0",
@@ -1088,7 +1088,7 @@
     },
     {
       "version": "v2022.05.24",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.12.0",
@@ -1104,7 +1104,7 @@
     },
     {
       "version": "v2022.03.28",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.11.0",
@@ -1120,7 +1120,7 @@
     },
     {
       "version": "v2022.02.22",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.10.0",
@@ -1136,7 +1136,7 @@
     },
     {
       "version": "v2021.12.21",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.9.2",
@@ -1148,7 +1148,7 @@
     },
     {
       "version": "v2021.11.24",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.9.0",
@@ -1160,7 +1160,7 @@
     },
     {
       "version": "v2021.11.18",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.8.0",
         "cli": "v0.23.0",
@@ -1171,7 +1171,7 @@
     },
     {
       "version": "v2021.09.30",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.7.0",
@@ -1183,7 +1183,7 @@
     },
     {
       "version": "v2021.09.09",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.6.0",
@@ -1195,7 +1195,7 @@
     },
     {
       "version": "v2021.08.23",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.5.0",
@@ -1207,7 +1207,7 @@
     },
     {
       "version": "v2021.06.23",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.4.0",
@@ -1219,7 +1219,7 @@
     },
     {
       "version": "v2021.06.21-rc.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.4.0-rc.0",
@@ -1231,7 +1231,7 @@
     },
     {
       "version": "v2021.04.16",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.3.0",
@@ -1243,7 +1243,7 @@
     },
     {
       "version": "v2021.03.17",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.2.1",
@@ -1255,7 +1255,7 @@
     },
     {
       "version": "v2021.03.11",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.2.0",
         "cli": "v0.17.0",
@@ -1267,7 +1267,7 @@
     },
     {
       "version": "v2021.01.26",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.1.2",
@@ -1279,7 +1279,7 @@
     },
     {
       "version": "v2021.01.15",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.1.1",
@@ -1291,7 +1291,7 @@
     },
     {
       "version": "v2021.01.14",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "autoscaler": "v0.1.0",
         "cli": "v0.16.0",
@@ -1302,7 +1302,7 @@
     },
     {
       "version": "v2021.01.02-rc.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "autoscaler": "v0.1.0-rc.0",
@@ -1314,7 +1314,7 @@
     },
     {
       "version": "v2020.12.10",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.15.2",
@@ -1325,7 +1325,7 @@
     },
     {
       "version": "v2020.11.12",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.15.1",
@@ -1336,7 +1336,7 @@
     },
     {
       "version": "v2020.11.11",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.15.0",
@@ -1347,7 +1347,7 @@
     },
     {
       "version": "v2020.11.08",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.14.1",
@@ -1358,7 +1358,7 @@
     },
     {
       "version": "v2020.10.28",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.14.0",
@@ -1369,7 +1369,7 @@
     },
     {
       "version": "v2020.10.27-rc.2",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "cli": "v0.14.0-rc.2",
         "community": "v0.14.0-rc.2",
@@ -1379,7 +1379,7 @@
     },
     {
       "version": "v2020.10.27-rc.1",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "cli": "v0.14.0-rc.1",
         "community": "v0.14.0-rc.1",
@@ -1389,7 +1389,7 @@
     },
     {
       "version": "v2020.10.27-rc.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "cli": "v0.14.0-beta.6",
         "community": "v0.14.0-beta.6",
@@ -1399,7 +1399,7 @@
     },
     {
       "version": "v2020.10.26-beta.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "cli": "v0.14.0-beta.5",
         "community": "v0.14.0-beta.5",
@@ -1409,7 +1409,7 @@
     },
     {
       "version": "v2020.10.24-beta.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "cli": "v0.14.0-beta.4",
         "community": "v0.14.0-beta.4",
@@ -1419,11 +1419,11 @@
     },
     {
       "version": "v2020.09.04-beta.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "v2020.07.10-beta.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "v0.13.0-rc.0",
@@ -1437,43 +1437,43 @@
     },
     {
       "version": "0.11.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.10.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.9.0-rc.2",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.9.0-rc.1",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.9.0-rc.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.9.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.8.0-rc.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.8.0-beta.2",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.8.0-beta.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.8.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.7.1",

--- a/data/products/kubeform.json
+++ b/data/products/kubeform.json
@@ -116,7 +116,7 @@
     },
     {
       "version": "v2022.05.11",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "alicloud": "v0.5.0",
@@ -150,7 +150,7 @@
     },
     {
       "version": "v2021.10.29",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "alicloud": "v0.4.0",
@@ -183,7 +183,7 @@
     },
     {
       "version": "v2021.08.02",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "alicloud": "v0.3.0",
@@ -214,7 +214,7 @@
     },
     {
       "version": "v2021.07.28",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "aws": "v0.2.0",

--- a/data/products/kubestash.json
+++ b/data/products/kubestash.json
@@ -382,7 +382,7 @@
     },
     {
       "version": "v2024.3.16",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.6.0",

--- a/data/products/kubevault.json
+++ b/data/products/kubevault.json
@@ -312,7 +312,7 @@
     },
     {
       "version": "v2024.3.12",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.18.0",
@@ -323,7 +323,7 @@
     },
     {
       "version": "v2024.1.31",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.17.0",
@@ -334,7 +334,7 @@
     },
     {
       "version": "v2024.1.28-rc.1",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "cli": "v0.17.0-rc.1",
         "installer": "v2024.1.28-rc.1",
@@ -344,7 +344,7 @@
     },
     {
       "version": "v2024.1.26-rc.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "cli": "v0.17.0-rc.0",
         "installer": "v2024.1.26-rc.0",
@@ -354,7 +354,7 @@
     },
     {
       "version": "v2023.9.7",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.16.0",
@@ -365,7 +365,7 @@
     },
     {
       "version": "v2023.05.05",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.15.0",
@@ -376,7 +376,7 @@
     },
     {
       "version": "v2023.03.03",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.14.0",
@@ -387,7 +387,7 @@
     },
     {
       "version": "v2022.12.28",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.13.0",
@@ -398,7 +398,7 @@
     },
     {
       "version": "v2022.12.09",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.12.0",
@@ -409,7 +409,7 @@
     },
     {
       "version": "v2022.11.30",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.11.0",
@@ -420,7 +420,7 @@
     },
     {
       "version": "v2022.09.22",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.10.0",
@@ -431,7 +431,7 @@
     },
     {
       "version": "v2022.09.09",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.9.0",
@@ -442,7 +442,7 @@
     },
     {
       "version": "v2022.09.05-rc.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.9.0-rc.0",
@@ -453,7 +453,7 @@
     },
     {
       "version": "v2022.06.16",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.8.0",
@@ -464,7 +464,7 @@
     },
     {
       "version": "v2022.02.22",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.7.0",
@@ -475,7 +475,7 @@
     },
     {
       "version": "v2022.01.11",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.6.0",
@@ -486,7 +486,7 @@
     },
     {
       "version": "v2021.10.11",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.5.1",
@@ -497,7 +497,7 @@
     },
     {
       "version": "v2021.09.27",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.5.0",
@@ -508,7 +508,7 @@
     },
     {
       "version": "v2021.08.02",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.4.0",

--- a/data/products/stash.json
+++ b/data/products/stash.json
@@ -836,7 +836,7 @@
     },
     {
       "version": "v2024.4.8",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.34.0",
@@ -917,7 +917,7 @@
     },
     {
       "version": "v2024.2.13",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.33.0",
@@ -997,7 +997,7 @@
     },
     {
       "version": "v2024.2.9-rc.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "cli": "v0.33.0-rc.0",
         "community": "v0.33.0-rc.0",
@@ -1076,7 +1076,7 @@
     },
     {
       "version": "v2023.10.9",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.32.0",
@@ -1156,7 +1156,7 @@
     },
     {
       "version": "v2023.08.18",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.31.0",
@@ -1236,7 +1236,7 @@
     },
     {
       "version": "v2023.05.31",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.30.0",
@@ -1315,7 +1315,7 @@
     },
     {
       "version": "v2023.04.30",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.29.0",
@@ -1394,7 +1394,7 @@
     },
     {
       "version": "v2023.03.20",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.28.0",
@@ -1472,7 +1472,7 @@
     },
     {
       "version": "v2023.03.13",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.27.0",
@@ -1550,7 +1550,7 @@
     },
     {
       "version": "v2023.02.28",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.26.0",
@@ -1628,7 +1628,7 @@
     },
     {
       "version": "v2023.01.05",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.25.0",
@@ -1706,7 +1706,7 @@
     },
     {
       "version": "v2022.12.11",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.24.0",
@@ -1784,7 +1784,7 @@
     },
     {
       "version": "v2022.09.29",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.23.0",
@@ -1858,7 +1858,7 @@
     },
     {
       "version": "v2022.07.09",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.22.0",
@@ -1931,7 +1931,7 @@
     },
     {
       "version": "v2022.06.27",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.21.0",
@@ -2004,7 +2004,7 @@
     },
     {
       "version": "v2022.06.21",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.21.0",
@@ -2077,7 +2077,7 @@
     },
     {
       "version": "v2022.05.18",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.20.0",
@@ -2150,7 +2150,7 @@
     },
     {
       "version": "v2022.05.12",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.20.0",
@@ -2221,7 +2221,7 @@
     },
     {
       "version": "v2022.03.29",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.19.0",
@@ -2289,7 +2289,7 @@
     },
     {
       "version": "v2022.02.22",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.18.0",
@@ -2357,7 +2357,7 @@
     },
     {
       "version": "v2021.11.24",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.17.0",
@@ -2424,7 +2424,7 @@
     },
     {
       "version": "v2021.10.11",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.16.0",
@@ -2490,7 +2490,7 @@
     },
     {
       "version": "v2021.08.02",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.15.0",
@@ -2548,7 +2548,7 @@
     },
     {
       "version": "v2021.06.23",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.14.1",
@@ -2602,7 +2602,7 @@
     },
     {
       "version": "v2021.6.18",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.14.0",
@@ -2656,7 +2656,7 @@
     },
     {
       "version": "v2021.04.12",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.12.3",
@@ -2813,7 +2813,7 @@
     },
     {
       "version": "v2021.03.17",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.12.0",
@@ -2866,7 +2866,7 @@
     },
     {
       "version": "v2021.03.11",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "catalog": "v2021.03.11",
         "cli": "v0.11.11",
@@ -2919,7 +2919,7 @@
     },
     {
       "version": "v2021.03.08",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "catalog": "v2021.03.08",
         "cli": "v0.11.10",
@@ -2972,7 +2972,7 @@
     },
     {
       "version": "v2021.01.21",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "catalog": "v2021.01.21",
@@ -3026,7 +3026,7 @@
     },
     {
       "version": "v2020.12.17",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "catalog": "v2020.12.17",
@@ -3079,7 +3079,7 @@
     },
     {
       "version": "v2020.11.17",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "catalog": "v2020.11.17",
@@ -3129,7 +3129,7 @@
     },
     {
       "version": "v2020.11.06",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "catalog": "v2020.11.06",
@@ -3178,7 +3178,7 @@
     },
     {
       "version": "v2020.10.30",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "catalog": "v2020.10.30",
@@ -3227,7 +3227,7 @@
     },
     {
       "version": "v2020.10.29",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "catalog": "v2020.10.29",
@@ -3276,7 +3276,7 @@
     },
     {
       "version": "v2020.10.21",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "catalog": "v2020.10.21",
@@ -3325,7 +3325,7 @@
     },
     {
       "version": "v2020.09.29",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "catalog": "v2020.09.29",
@@ -3373,7 +3373,7 @@
     },
     {
       "version": "v2020.09.16",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "catalog": "v2020.09.16",
@@ -3421,7 +3421,7 @@
     },
     {
       "version": "v2020.08.27-rc.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "catalog": "v2020.08.27-rc.0",
         "cli": "v0.10.0-rc.2",
@@ -3431,7 +3431,7 @@
     },
     {
       "version": "v2020.08.27",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "catalog": "v2020.08.27",
@@ -3442,7 +3442,7 @@
     },
     {
       "version": "v2020.08.26-rc.1",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "catalog": "v2020.08.26-rc.1",
         "cli": "v0.10.0-rc.1"
@@ -3450,7 +3450,7 @@
     },
     {
       "version": "v2020.08.26-rc.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "catalog": "v2020.08.26-rc.0",
         "cli": "v0.10.0-rc.0"
@@ -3458,7 +3458,7 @@
     },
     {
       "version": "v2020.07.09-beta.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "catalog": "v2020.07.09-beta.0",
         "cli": "v0.10.0-beta.1"
@@ -3466,7 +3466,7 @@
     },
     {
       "version": "v2020.07.08-beta.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "catalog": "v2020.07.08-beta.0",
         "cli": "v0.10.0-beta.0"
@@ -3474,7 +3474,7 @@
     },
     {
       "version": "v0.9.0-rc.6",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "catalog": "v0.3.0",
@@ -3483,7 +3483,7 @@
     },
     {
       "version": "v0.9.0-rc.4",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "catalog": "v0.2.0",
         "cli": "v0.3.0"
@@ -3491,7 +3491,7 @@
     },
     {
       "version": "v0.9.0-rc.2",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "catalog": "v0.1.0",
         "cli": "v0.2.0"
@@ -3499,7 +3499,7 @@
     },
     {
       "version": "v0.9.0-rc.1",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "catalog": "v0.1.0",
         "cli": "v0.1.0"
@@ -3507,71 +3507,71 @@
     },
     {
       "version": "v0.9.0-rc.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.8.3",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.8.2",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.8.1",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.8.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.7.0-rc.5",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.7.0-rc.4",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.7.0-rc.3",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.7.0-rc.2",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.7.0-rc.1",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.7.0-rc.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.7.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.6.4",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.6.3",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.6.2",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.6.1",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.6.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "0.5.1",

--- a/data/products/voyager.json
+++ b/data/products/voyager.json
@@ -169,7 +169,7 @@
     },
     {
       "version": "v2024.3.18",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.0.15",
@@ -178,7 +178,7 @@
     },
     {
       "version": "v2023.9.18",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.0.14",
@@ -187,7 +187,7 @@
     },
     {
       "version": "v2023.05.16",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.0.13",
@@ -196,7 +196,7 @@
     },
     {
       "version": "v2023.02.22",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.0.12",
@@ -205,7 +205,7 @@
     },
     {
       "version": "v2022.12.11",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.0.11",
@@ -214,7 +214,7 @@
     },
     {
       "version": "v2022.08.17",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.0.10",
@@ -223,7 +223,7 @@
     },
     {
       "version": "v2022.06.20",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.0.9",
@@ -232,7 +232,7 @@
     },
     {
       "version": "v2022.04.13",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.0.8",
@@ -241,7 +241,7 @@
     },
     {
       "version": "v2022.03.17",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.0.7",
@@ -250,7 +250,7 @@
     },
     {
       "version": "v2022.02.22",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.0.6",
@@ -259,7 +259,7 @@
     },
     {
       "version": "v2022.01.10",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.0.5",
@@ -268,7 +268,7 @@
     },
     {
       "version": "v2022.01.07",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.0.4",
@@ -277,7 +277,7 @@
     },
     {
       "version": "v2022.01.01",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.0.4",
@@ -286,7 +286,7 @@
     },
     {
       "version": "v2021.10.18",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "cli": "v0.0.3",
@@ -295,21 +295,21 @@
     },
     {
       "version": "v2021.10.17",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "installer": "v2021.10.17"
       }
     },
     {
       "version": "v2021.10.16",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "installer": "v2021.10.16"
       }
     },
     {
       "version": "v2021.09.15",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true,
       "info": {
         "installer": "v2021.09.15"
@@ -317,7 +317,7 @@
     },
     {
       "version": "v2021.04.24-rc.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "info": {
         "installer": "v2021.04.24-rc.0"
       }
@@ -331,11 +331,11 @@
     },
     {
       "version": "v13.0.0-beta.1",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "v13.0.0-beta.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "v12.0.0-rc.2",
@@ -343,104 +343,104 @@
     },
     {
       "version": "v12.0.0-rc.1",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "v12.0.0-rc.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "v12.0.0",
-      "hostDocs": true,
+      "hostDocs": false,
       "show": true
     },
     {
       "version": "v11.0.1",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "v11.0.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "10.0.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "9.0.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "8.0.1",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "8.0.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "7.4.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "7.3.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "7.2.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "7.1.1",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "7.1.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "7.0.0-rc.3",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "7.0.0-rc.2",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "7.0.0-rc.1",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "7.0.0-rc.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "7.0.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "6.0.0-rc.2",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "6.0.0-rc.1",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "6.0.0-rc.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "6.0.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "5.0.0-rc.11",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "5.0.0",
-      "hostDocs": true
+      "hostDocs": false
     },
     {
       "version": "3.2.2",


### PR DESCRIPTION
## Summary
- set hostDocs to false for dated versions older than 2 years
- applied the update across product JSON files under data/products

## Criteria
- cutoff date used: 2024-04-20 (2 years before 2026-04-20)
- only date-formatted versions (for example vYYYY.M.D with optional rc/beta suffix) were auto-evaluated

## Files changed
- data/products/kubedb.json
- data/products/kubeform.json
- data/products/kubestash.json
- data/products/kubevault.json
- data/products/stash.json
- data/products/voyager.json