### PR TITLE
Update for release KubeStash@v2026.4.27

### DIFF
--- a/data/products/kubestash.json
+++ b/data/products/kubestash.json
@@ -177,6 +177,15 @@
       "show": true
     },
     {
+      "version": "v2026.4.27",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.26.0",
+        "installer": "v2026.4.27"
+      }
+    },
+    {
       "version": "v2026.4.13-rc.0",
       "hostDocs": true,
       "show": true,
@@ -390,7 +399,7 @@
       }
     }
   ],
-  "latestVersion": "v2026.2.26",
+  "latestVersion": "v2026.4.27",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubestash",


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2026.4.27
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/46