### PR TITLE
Modernize CI/publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
         id: go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,21 +4,26 @@ on:
   pull_request:
     branches: [master]
   workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@v4
+
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
           go-version: '1.25'
         id: go
-
-      - uses: actions/checkout@v4
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       GITHUB_USER: 1gtm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Configure S3 CLI
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,15 +4,21 @@ on:
   push:
     branches:
       - master
-
   workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    env:
+      GITHUB_USER: 1gtm
 
     steps:
       - uses: actions/checkout@v4
@@ -21,41 +27,33 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
-          AWS_S3_ENDPOINT: ${{ secrets.CLOUDFLARE_R2_ENDPOINT }}
         run: |
           echo "install aws cli"
           sudo apt-get -qq update || true
-          sudo apt-get install -y python3-pip
-          pip3 install awscli
+          sudo apt-get install -y awscli
           echo
           echo "configure aws credentials"
           aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
           aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
           aws configure set region us-east-1
           aws configure set s3.signature_version s3v4
-          aws configure set endpoint_url $AWS_S3_ENDPOINT
 
       - name: Prepare git
         env:
-          GITHUB_USER: 1gtm
           GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
         run: |
           git config --global user.name "${GITHUB_USER}"
           git config --global user.email "${GITHUB_USER}@appscode.com"
           git remote set-url origin https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
 
-      - name: Install GitHub CLI
-        run: |
-          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          sudo mv bin/hub /usr/local/bin
-
       - name: Publish
+        env:
+          AWS_ENDPOINT_URL: ${{ secrets.CLOUDFLARE_R2_ENDPOINT }}
         run: |
           make publish
 
       - name: Update release tracker
         env:
-          GITHUB_USER: 1gtm
           GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
         run: |
           ./hack/scripts/update-release-tracker.sh

--- a/hack/scripts/update-release-tracker.sh
+++ b/hack/scripts/update-release-tracker.sh
@@ -55,4 +55,4 @@ parse_url $RELEASE_TRACKER
 api_url="repos/${RELEASE_TRACKER_OWNER}/${RELEASE_TRACKER_REPO}/issues/${RELEASE_TRACKER_PR}/comments"
 # This is the only remote tagged message. We do NOT really tag. We are faking it to the release automaton.
 msg="/tagged github.com/${GITHUB_REPOSITORY}"
-hub api "$api_url" -f body="$msg"
+gh api "$api_url" -f body="$msg"


### PR DESCRIPTION
## Summary
- **ci.yml**: move `checkout` before `setup-go` so `actions/setup-go@v5`'s built-in module caching can find `go.sum`; add `permissions: contents: read`.
- **publish.yml**: install `awscli` via `apt` instead of `pip3` (PEP 668 makes system pip installs error on ubuntu-24.04); drop the archived `github/hub` install step since `gh` is pre-installed on the runner; replace the non-standard `aws configure set endpoint_url` with `AWS_ENDPOINT_URL` env on the Publish step (supported in AWS CLI v2.13+); lift `GITHUB_USER: 1gtm` to job-level env; add `permissions: contents: read`.
- **hack/scripts/update-release-tracker.sh**: switch `hub api` to `gh api` (same flags, same `GITHUB_TOKEN` env pickup).

## Test plan
- [ ] CI workflow runs green on this PR.
- [ ] After merge, verify the next Publish run on `master`:
  - [ ] `apt-get install awscli` succeeds.
  - [ ] `aws s3 sync` reaches the R2 bucket via `AWS_ENDPOINT_URL`.
  - [ ] `gh api` posts the `/tagged` comment to the release tracker.