### PR TITLE
Fix Publish workflow: drop awscli apt install

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,10 +28,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
         run: |
-          echo "install aws cli"
-          sudo apt-get -qq update || true
-          sudo apt-get install -y awscli
-          echo
           echo "configure aws credentials"
           aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
           aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
## Summary
- The `awscli` package was removed from Ubuntu 24.04's apt repos, breaking the Publish workflow with `E: Package 'awscli' has no installation candidate` ([failed run](https://github.com/appscode/static-assets/actions/runs/25867526311/job/76013529895)).
- AWS CLI v2 is preinstalled on GitHub's `ubuntu-24.04` runner image, so the install step is unnecessary — kept the `aws configure` calls.

## Test plan
- [ ] Publish workflow succeeds on the next push to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)