### PR TITLE
Update for release KubeVault@v2026.5.18-rc.1

### DIFF
--- a/data/products/kubevault.json
+++ b/data/products/kubevault.json
@@ -223,6 +223,17 @@
       "show": true
     },
     {
+      "version": "v2026.5.18-rc.1",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.25.0-rc.1",
+        "installer": "v2026.5.18-rc.1",
+        "operator": "v0.25.0-rc.1",
+        "unsealer": "v0.25.0-rc.1"
+      }
+    },
+    {
       "version": "v2026.5.14-rc.0",
       "hostDocs": true,
       "show": true,


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2026.5.18-rc.1
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/69