### PR TITLE
Update for release KubeStash@v2026.5.18-rc.0

### DIFF
--- a/data/products/kubestash.json
+++ b/data/products/kubestash.json
@@ -177,6 +177,15 @@
       "show": true
     },
     {
+      "version": "v2026.5.18-rc.0",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.27.0-rc.0",
+        "installer": "v2026.5.18-rc.0"
+      }
+    },
+    {
       "version": "v2026.4.27",
       "hostDocs": true,
       "show": true,
@@ -399,7 +408,7 @@
       }
     }
   ],
-  "latestVersion": "v2026.4.27",
+  "latestVersion": "v2026.5.18-rc.0",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubestash",


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2026.5.18-rc.0
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/49