### PR TITLE
Update for release KubeDB@v2026.5.18-rc.0

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2026.5.18-rc.0",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.50.0-rc.0",
+        "cli": "v0.65.0-rc.0",
+        "dashboard": "v0.41.0-rc.0",
+        "installer": "v2026.5.18-rc.0",
+        "ops-manager": "v0.52.0-rc.0",
+        "provisioner": "v0.65.0-rc.0",
+        "schema-manager": "v0.41.0-rc.0",
+        "ui-server": "v0.41.0-rc.0",
+        "webhook-server": "v0.41.0-rc.0"
+      }
+    },
+    {
       "version": "v2026.4.27",
       "hostDocs": true,
       "show": true,
@@ -175,7 +190,6 @@
     {
       "version": "v2026.4.13-rc.0",
       "hostDocs": false,
-      "show": false,
       "info": {
         "autoscaler": "v0.49.0-rc.0",
         "cli": "v0.64.0-rc.0",


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2026.5.18-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/135