### PR TITLE
Update for release KubeDB@v2026.6.18-rc.2

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2026.6.18-rc.2",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.50.0-rc.2",
+        "cli": "v0.65.0-rc.2",
+        "dashboard": "v0.41.0-rc.2",
+        "installer": "v2026.6.18-rc.2",
+        "ops-manager": "v0.52.0-rc.2",
+        "provisioner": "v0.65.0-rc.2",
+        "schema-manager": "v0.41.0-rc.2",
+        "ui-server": "v0.41.0-rc.2",
+        "webhook-server": "v0.41.0-rc.2"
+      }
+    },
+    {
       "version": "v2026.6.5-rc.1",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2026.6.18-rc.2
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/138