### PR TITLE
Update for release KubeStash@v2026.6.19

### DIFF
--- a/data/products/kubestash.json
+++ b/data/products/kubestash.json
@@ -177,6 +177,15 @@
       "show": true
     },
     {
+      "version": "v2026.6.19",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.27.0",
+        "installer": "v2026.6.19"
+      }
+    },
+    {
       "version": "v2026.6.18-rc.2",
       "hostDocs": true,
       "show": true,
@@ -417,7 +426,7 @@
       }
     }
   ],
-  "latestVersion": "v2026.4.27",
+  "latestVersion": "v2026.6.19",
   "socialLinks": {
     "facebook": "https://facebook.com/appscode",
     "github": "https://github.com/kubestash",


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2026.6.19
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/52