### PR TITLE
Update for release KubeDB@v2026.6.19

### DIFF
--- a/data/products/kubedb.json
+++ b/data/products/kubedb.json
@@ -157,6 +157,21 @@
       "show": true
     },
     {
+      "version": "v2026.6.19",
+      "hostDocs": true,
+      "info": {
+        "autoscaler": "v0.50.0",
+        "cli": "v0.65.0",
+        "dashboard": "v0.41.0",
+        "installer": "v2026.6.19",
+        "ops-manager": "v0.52.0",
+        "provisioner": "v0.65.0",
+        "schema-manager": "v0.41.0",
+        "ui-server": "v0.41.0",
+        "webhook-server": "v0.41.0"
+      }
+    },
+    {
       "version": "v2026.6.18-rc.2",
       "hostDocs": true,
       "info": {


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2026.6.19
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/139