### PR TITLE
Add air-gapped clusters pricing FAQ for KubeDB

### DIFF
--- a/data/products/kubedb/pricing/faq.json
+++ b/data/products/kubedb/pricing/faq.json
@@ -38,6 +38,10 @@
     {
       "question": "Do you offer professional services?",
       "answer": "Yes. Professional services are available for implementation and productization directly and via channel partners. Contact sales for a custom quote."
+    },
+    {
+      "question": "How is pricing calculated for air-gapped clusters with no external monitoring?",
+      "answer": "Air-gapped clusters are supported. Contact sales@appscode.com to discuss custom pricing options."
     }
   ]
 }


### PR DESCRIPTION
Adds a new FAQ entry to the KubeDB pricing page explaining that air-gapped clusters with no external monitoring are supported, and directing customers to contact sales@appscode.com for custom pricing options.