### PR TITLE
Update for release KubeVault@v2026.7.24-rc.2

### DIFF
--- a/data/products/kubevault.json
+++ b/data/products/kubevault.json
@@ -223,6 +223,17 @@
       "show": true
     },
     {
+      "version": "v2026.7.24-rc.2",
+      "hostDocs": true,
+      "show": true,
+      "info": {
+        "cli": "v0.25.0-rc.2",
+        "installer": "v2026.7.24-rc.2",
+        "operator": "v0.25.0-rc.2",
+        "unsealer": "v0.25.0-rc.2"
+      }
+    },
+    {
       "version": "v2026.5.18-rc.1",
       "hostDocs": true,
       "show": true,
@@ -236,7 +247,6 @@
     {
       "version": "v2026.5.14-rc.0",
       "hostDocs": false,
-      "show": false,
       "info": {
         "cli": "v0.25.0-rc.0",
         "installer": "v2026.5.14-rc.0",
@@ -258,7 +268,6 @@
     {
       "version": "v2026.1.8-rc.0",
       "hostDocs": false,
-      "show": false,
       "info": {
         "cli": "v0.24.0-rc.0",
         "installer": "v2026.1.8-rc.0",


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2026.7.24-rc.2
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/70